### PR TITLE
feat: l1-run headless L1 runner (direct LLM API calls, cron/CI-schedulable)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ abap_wiki/.obsidian/cache/
 # Local MCP config: may contain local credentials or tokens.
 .mcp.json
 
+# Local LLM profiles for the headless runner: names env vars, never keys,
+# but the endpoints/models are the user's local setup and must not be tracked.
+llm-profiles.yaml
+
 # Real SAP data in the operational inbox must NEVER be published.
 # The root raw/ inbox holds the user's real SAP exports in an operational clone;
 # only the scaffold (README / .gitkeep) is tracked. The public demo sources live

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,8 +185,9 @@ emitting the event AND rendering it in `oplog.build_entries` (never one without 
 
 Single entry point: `core/src/tools/pipeline.py`. Bootstrap/utility sub-commands:
 `init-db`, `migrate`, `import-tadir`, `resolve-sources`, `ingest-l0`, `enqueue-l1`,
-`progress`, `l0-run` (one-shot deterministic L0 sequence, no LLM), `slices-registry`,
-`check-headers`, `ingest-metadata` (deterministic DDIC
+`progress`, `l0-run` (one-shot deterministic L0 sequence, no LLM),
+`l1-run` (headless L1 loop via direct LLM calls, config llm-profiles.yaml),
+`slices-registry`, `check-headers`, `ingest-metadata` (deterministic DDIC
 metadata pages for data-element/message-class, stays L0). L1 loop sub-commands: `claim`,
 `submit-author`, `submit-verdict` (with the `--override-threshold/--operator/--reason` valve),
 `apply`, `recover`, `project`, `git-commit`, `log`, `log-op`, `export-excel`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `abap_wiki` are documented in this file. The format is
 inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 follow [SemVer](https://semver.org/lang/en/).
 
+## [1.2.0]
+
+### Added
+
+- **Headless L1 runner**: `l1-run`, a fourth door into the L1 loop via direct
+  LLM API calls (no chat runner, no VS Code, schedulable from cron/CI) - a
+  two-profile `llm-profiles.yaml` config (author/judge, `anthropic`/`openai`
+  wire shapes, keys from environment only), the same fail-closed adversarial
+  gate and canonical contracts as the chat runners, and end-to-end tests
+  against a local HTTP stub impersonating both wire shapes.
+- `llm-profiles.yaml.example`: tracked, credential-free template for the
+  headless runner config.
+
 ## [1.0.0] - 2026-07-08
 
 First public release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,8 +185,9 @@ emitting the event AND rendering it in `oplog.build_entries` (never one without 
 
 Single entry point: `core/src/tools/pipeline.py`. Bootstrap/utility sub-commands:
 `init-db`, `migrate`, `import-tadir`, `resolve-sources`, `ingest-l0`, `enqueue-l1`,
-`progress`, `l0-run` (one-shot deterministic L0 sequence, no LLM), `slices-registry`,
-`check-headers`, `ingest-metadata` (deterministic DDIC
+`progress`, `l0-run` (one-shot deterministic L0 sequence, no LLM),
+`l1-run` (headless L1 loop via direct LLM calls, config llm-profiles.yaml),
+`slices-registry`, `check-headers`, `ingest-metadata` (deterministic DDIC
 metadata pages for data-element/message-class, stays L0). L1 loop sub-commands: `claim`,
 `submit-author`, `submit-verdict` (with the `--override-threshold/--operator/--reason` valve),
 `apply`, `recover`, `project`, `git-commit`, `log`, `log-op`, `export-excel`,

--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ Full architecture: `core/docs/00-architecture.md` (also `02-adversarial-gate.md`
 - `14-abap-fs-integration.md`: provisioning and feeding an instance from ABAP FS
   (release-zip wizard, TADIR/source download via ABAP FS tools, `l0-run`, runner
   setup including Copilot), per issue #473.
+- `15-headless-l1-runner.md`: the `l1-run` headless L1 loop (direct LLM API
+  calls, no chat runner, cron/CI-friendly), configuration and exit codes.
 
 ## Agents
 
@@ -419,6 +421,8 @@ Full architecture: `core/docs/00-architecture.md` (also `02-adversarial-gate.md`
   your choice; it is the only hand-editable line, and the drift check ignores it).
   Copilot agent mode reads the skills from `.agents/skills/` natively and loads
   `AGENTS.md` via the `chat.useAgentsMdFile` setting.
+- Headless (`l1-run`): no agentic runner required, direct LLM API calls
+  instead - schedulable from cron/CI. See `core/docs/15-headless-l1-runner.md`.
 
 The canonical contracts live in `core/src/agentic/programs/` and are synchronised with:
 

--- a/core/docs/05-runbook.md
+++ b/core/docs/05-runbook.md
@@ -240,6 +240,7 @@ All commands run as `pipeline.py <subcommand>` from the repo root with the venv 
 | `enqueue-l1` | Enqueue the `l1_author` tasks for `l1_ready` objects |
 | `progress` | Progress statistics |
 | `l0-run` | one-shot wrapper that runs the whole L0 bootstrap sequence (init-db -> import-tadir -> resolve-sources -> ingest-l0 -> enqueue-l1 -> progress) and stops at the first failure. Same guarantees as the single steps: deterministic, idempotent, no LLM. |
+| `l1-run` | headless L1 loop via direct LLM API calls (config: `llm-profiles.yaml`, see [core/docs/15-headless-l1-runner.md](15-headless-l1-runner.md)) |
 | `slices-registry` | Regenerate `slices.yaml` from the slice manifests |
 | `check-headers` | Verify context headers on engine code files (`--fix` to create missing) |
 | `ingest-metadata` | Deterministic DDIC metadata pages for data-element/message-class (no LLM, L0) |

--- a/core/docs/11-agent-runtime-and-cost.md
+++ b/core/docs/11-agent-runtime-and-cost.md
@@ -96,3 +96,12 @@ only thing agents write, promotion is fail-closed behind the gate, and
 `pipeline.py recover` + `submit-author --fail` resume exactly where the batch
 stopped - observed live, twice, during the batch measured above. Details:
 [12-faq-and-troubleshooting](12-faq-and-troubleshooting.md).
+
+## 6. Headless runner
+
+`pipeline.py l1-run` (direct LLM API calls, no chat runner) removes the
+orchestration overhead above: chat runners pass every claim/submit/apply
+through agent turns, but here the model is called exactly twice per object
+(one author completion, one judge completion). Cost becomes those two
+completions only - no extra turns to plan, call tools, or narrate the
+loop. Config and usage: [15-headless-l1-runner](15-headless-l1-runner.md).

--- a/core/docs/14-abap-fs-integration.md
+++ b/core/docs/14-abap-fs-integration.md
@@ -88,6 +88,12 @@ either way no LLM shapes the result.
 - The adversarial gate contract is runner-independent: author and judge
   must run on different models, and no promotion happens without an ACCEPT
   verdict (fail-closed), whatever the runner.
+- **Headless (`l1-run`)**: the programmatic path a VS Code command or a
+  Copilot-proxy setup can drive without an interactive agent
+  ([15-headless-l1-runner](15-headless-l1-runner.md)). "Config wiki to use
+  abapfs for inference" means pointing `base_url` in `llm-profiles.yaml` at
+  the proxy endpoint, with `api_shape` matching its wire form
+  (`anthropic` or `openai`). No ABAP FS changes required.
 
 ## 5. Live SAP access (optional, read-only)
 

--- a/core/docs/15-headless-l1-runner.md
+++ b/core/docs/15-headless-l1-runner.md
@@ -1,0 +1,62 @@
+# Headless L1 runner (`l1-run`)
+
+One command that runs the whole L1 loop (author + adversarial judge) via
+direct LLM API calls: no chat runner, no VS Code, schedulable from cron/CI.
+A fourth door into the same pipeline, additive: Claude Code, Codex CLI and
+the Copilot projection keep working unchanged, on the same state and gate.
+
+> **Scope.** The `l1-run` command: when to use it, the `llm-profiles.yaml`
+> configuration, usage and exit codes, the guarantees it shares with the
+> chat runners, and how it is tested.
+> **Prerequisites.** README "Getting started" (Python >= 3.11) and an
+> L1-ready queue (L0 already run: [09-first-clone-and-sap-input-guide](09-first-clone-and-sap-input-guide.md)).
+> **See also.** The batch cycle it drives: [01-pipeline-l0-l1](01-pipeline-l0-l1.md) §7;
+> gate semantics: [02-adversarial-gate](02-adversarial-gate.md); the chat
+> runners and model split: [11-agent-runtime-and-cost](11-agent-runtime-and-cost.md);
+> ABAP FS as a caller of this command: [14-abap-fs-integration](14-abap-fs-integration.md).
+
+## When to use it
+
+- Scheduled ingest (nightly cron, CI step) with nobody at the keyboard.
+- Batch L1 on a server/container without an interactive agent.
+- As the programmatic inference path for integrations (e.g. ABAP FS `create_wiki`
+  scenarios, issue #473): anything that can set env vars and run Python can run L1.
+
+## Configuration
+
+Copy `llm-profiles.yaml.example` (repo root) to `llm-profiles.yaml` (gitignored)
+and fill in the two profiles (author, judge): `api_shape` (`anthropic` |
+`openai`), `base_url`, `model`, `api_key_env` (+ optional `max_tokens`,
+`timeout_sec`). API keys live ONLY in environment variables named by
+`api_key_env`, never in the file. A same-model author/judge pair is accepted
+with a warning: a different judge model stays the recommendation (the hard
+guarantee - context separation - holds anyway: two independent calls).
+
+## Usage
+
+    python core/src/tools/pipeline.py l1-run [--package ZFOO] [--limit 10]
+        [--max-batches 20] [--profiles path/to/llm-profiles.yaml]
+
+Per batch: recover -> claim l1_author -> one LLM call per object (contract +
+runtime addendum as system; template + numbered raw sources + any REVERT
+feedback as user) -> submit-author -> claim l1_deepcheck -> one LLM call on
+the pre-rendered deepcheck prompt -> submit-verdict -> apply -> project ->
+export -> git commit. Stops when the queue drains or --max-batches is hit.
+
+Exit codes: 0 = queue drained, no hard failures; 1 = open work or failures
+remain; 2 = preflight/config error (nothing touched).
+
+## Guarantees (identical to the chat runners)
+
+- Canonical contracts unchanged; the addendum is composed at runtime.
+- Fail-closed gate inherited: invalid YAML/JSON is rejected by
+  submit-author/submit-verdict; a missing verdict is BLOCKED, never ACCEPT.
+- REVERT feedback: the gate's rejected-claims.json is injected into the
+  retry prompt (same task id, same artifact dir, one run_id per invocation).
+- Secrets/customer code never logged: only counts, model names, outcomes.
+
+## Testing
+
+Unit + e2e without secrets: a local HTTP stub impersonates both wire shapes
+(test_headless_e2e.py). Optional live smoke on the demo dataset:
+set ABAPWIKI_LIVE_SMOKE=1 plus a real key locally; never in CI.

--- a/core/docs/15-headless-l1-runner.md
+++ b/core/docs/15-headless-l1-runner.md
@@ -34,8 +34,10 @@ guarantee - context separation - holds anyway: two independent calls).
 
 ## Usage
 
-    python core/src/tools/pipeline.py l1-run [--package ZFOO] [--limit 10]
-        [--max-batches 20] [--profiles path/to/llm-profiles.yaml]
+```
+python core/src/tools/pipeline.py l1-run [--package ZFOO] [--limit 10]
+    [--max-batches 20] [--profiles path/to/llm-profiles.yaml]
+```
 
 Per batch: recover -> claim l1_author -> one LLM call per object (contract +
 runtime addendum as system; template + numbered raw sources + any REVERT
@@ -51,8 +53,10 @@ remain; 2 = preflight/config error (nothing touched).
 - Canonical contracts unchanged; the addendum is composed at runtime.
 - Fail-closed gate inherited: invalid YAML/JSON is rejected by
   submit-author/submit-verdict; a missing verdict is BLOCKED, never ACCEPT.
-- REVERT feedback: the gate's rejected-claims.json is injected into the
-  retry prompt (same task id, same artifact dir, one run_id per invocation).
+- REVERT feedback: the gate writes its findings (rejected-claims.json) into
+  the rejected attempt's artifact dir; the runner locates it through the
+  object's previous author tasks in the DB (across run boundaries) and
+  injects it into the retry prompt.
 - Secrets/customer code never logged: only counts, model names, outcomes.
 
 ## Testing

--- a/core/docs/15-headless-l1-runner.md
+++ b/core/docs/15-headless-l1-runner.md
@@ -64,3 +64,15 @@ remain; 2 = preflight/config error (nothing touched).
 Unit + e2e without secrets: a local HTTP stub impersonates both wire shapes
 (test_headless_e2e.py). Optional live smoke on the demo dataset:
 set ABAPWIKI_LIVE_SMOKE=1 plus a real key locally; never in CI.
+
+## Troubleshooting interrupted runs
+
+A persistent exit code 1 across invocations, with no LLM spend, usually
+means work orphaned by an interrupted run:
+
+- queued `l1_apply` tasks (accepted but never applied): run
+  `pipeline.py apply --run <id> --batch <id>` followed by `project` and
+  `git-commit`, or let a chat-runner round complete the batch;
+- an orphaned deepcheck task whose rendered prompt lives in an old run dir
+  (fail-closed BLOCKED on every retry, by design): reopen the object with
+  `pipeline.py reopen-l1 --object <id>` and let the next `l1-run` redo it.

--- a/core/src/test/unit_tests/conftest.py
+++ b/core/src/test/unit_tests/conftest.py
@@ -53,6 +53,7 @@ def repo(tmp_path, monkeypatch):
         "raw/system-library/ZTEST/Source Code Library/Programmi/ZTEST_PROG",
         "raw/system-library/ZTEST/Dictionary",
         "core/src/agentic/audit",
+        "core/src/agentic/programs",
         "templates",
     ):
         (root / d).mkdir(parents=True, exist_ok=True)
@@ -71,6 +72,16 @@ def repo(tmp_path, monkeypatch):
     )
     (root / "raw/system-library/ZTEST/Dictionary" / "ECRS_DIREC.dtel.xml").write_bytes(
         b'<?xml version="1.0"?><DTEL><NAME>/ECRS/DIREC</NAME></DTEL>\n'
+    )
+
+    # Create contract files with frontmatter and body
+    (root / "core/src/agentic/programs" / "00-abap-analyzer.md").write_text(
+        "---\nmodel: inherit\n---\n\n# ABAP Analyzer\n\nThis is the analyzer contract.\n",
+        encoding="utf-8",
+    )
+    (root / "core/src/agentic/programs" / "00-abap-deepcheck.md").write_text(
+        "---\nmodel: inherit\n---\n\n# ABAP Deepcheck\n\nThis is the deepcheck contract.\n",
+        encoding="utf-8",
     )
 
     monkeypatch.setattr(dbmod, "repo_root", lambda: root)

--- a/core/src/test/unit_tests/conftest.py
+++ b/core/src/test/unit_tests/conftest.py
@@ -53,7 +53,6 @@ def repo(tmp_path, monkeypatch):
         "raw/system-library/ZTEST/Source Code Library/Programmi/ZTEST_PROG",
         "raw/system-library/ZTEST/Dictionary",
         "core/src/agentic/audit",
-        "core/src/agentic/programs",
         "templates",
     ):
         (root / d).mkdir(parents=True, exist_ok=True)
@@ -72,16 +71,6 @@ def repo(tmp_path, monkeypatch):
     )
     (root / "raw/system-library/ZTEST/Dictionary" / "ECRS_DIREC.dtel.xml").write_bytes(
         b'<?xml version="1.0"?><DTEL><NAME>/ECRS/DIREC</NAME></DTEL>\n'
-    )
-
-    # Create contract files with frontmatter and body
-    (root / "core/src/agentic/programs" / "00-abap-analyzer.md").write_text(
-        "---\nmodel: inherit\n---\n\n# ABAP Analyzer\n\nThis is the analyzer contract.\n",
-        encoding="utf-8",
-    )
-    (root / "core/src/agentic/programs" / "00-abap-deepcheck.md").write_text(
-        "---\nmodel: inherit\n---\n\n# ABAP Deepcheck\n\nThis is the deepcheck contract.\n",
-        encoding="utf-8",
     )
 
     monkeypatch.setattr(dbmod, "repo_root", lambda: root)

--- a/core/src/test/unit_tests/test_headless_e2e.py
+++ b/core/src/test/unit_tests/test_headless_e2e.py
@@ -1,0 +1,250 @@
+"""End-to-end tests of `pipeline.py l1-run` against a local HTTP LLM stub.
+
+What it does: proves the whole headless loop works over real localhost HTTP -
+author on the Anthropic wire shape, judge on the OpenAI wire shape - on the
+synthetic ZTEST fixture: happy path to L1 + git commit, REVERT-then-retry with
+gate feedback injected into the second author prompt, and broken author output
+surfacing as exit code 1 without promotion. No API keys: the stub is local.
+How it works: an http.server ThreadingHTTPServer (module-captured real socket:
+the conftest block_network stub is bypassed for 127.0.0.1 only) replies with
+the canned author.yaml/deepcheck.json that the real pipeline already accepts
+(reused from test_l1_cycle); the repo fixture gets git init + llm-profiles.yaml
+pointing at the stub; the test drives pipeline.main(["l1-run", ...]).
+Connections: exercises headless_l1 + llm_client + pipeline wiring end-to-end
+with cli_loop/gitops/oplog; consumes conftest.py and test_l1_cycle fixtures.
+"""
+
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import db
+import headless_l1
+import pipeline
+import pytest
+import yaml
+from test_headless_l1 import _seed_claimed_author, _write_contracts, _write_template
+from test_l1_cycle import _author_yaml
+
+_REAL_SOCKET = socket.socket  # captured at import time, before block_network runs
+
+
+@pytest.fixture(autouse=True)
+def allow_localhost(block_network):
+    """The stub needs a real socket; only 127.0.0.1 is ever contacted."""
+    import sys as _sys
+
+    socket.socket = _REAL_SOCKET
+    _sys.modules["socket"].socket = _REAL_SOCKET
+    yield  # block_network's teardown restores the real socket anyway
+
+
+class _StubHandler(BaseHTTPRequestHandler):
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("content-length", 0))
+        body = json.loads(self.rfile.read(length).decode("utf-8"))
+        self.server.requests.append({"path": self.path, "body": body})
+        if self.path == "/v1/messages":  # author profile (anthropic shape)
+            text = self.server.author_reply(body)
+            payload = {"content": [{"type": "text", "text": text}], "stop_reason": "end_turn"}
+        else:  # judge profile (openai shape): /v1/chat/completions
+            text = self.server.judge_reply(body)
+            payload = {"choices": [{"message": {"content": text}, "finish_reason": "stop"}]}
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def _canned_author_text():
+    return "```yaml\n" + yaml.safe_dump(_author_yaml(), allow_unicode=True, sort_keys=False) + "```"
+
+
+def _verdict_from_prompt(body, *, supported=True):
+    """Builds the verdict by echoing the CL-/DEP- ids and the object_slug found
+    in the judge prompt (exactly what a real judge must cover)."""
+    user = body["messages"][1]["content"]
+    slug = re.search(r"object_slug: (\S+)", user).group(1)
+    claim_ids = sorted(set(re.findall(r"\bCL-\d{3}\b", user)))
+    dep_ids = sorted(set(re.findall(r"\bDEP-\d{3}\b", user)))
+    verdicts = [
+        {
+            "claim_id": c,
+            "class": "behavior",
+            "verdict": "supported" if supported else "not_supported",
+            "confidence": "high",
+            "rationale": "ok",
+        }
+        for c in claim_ids
+    ]
+    deps = [
+        {"dep_id": d, "name": "MSEG", "verdict": "confirmed", "confidence": "high"} for d in dep_ids
+    ]
+    return json.dumps({"object_slug": slug, "verdicts": verdicts, "dependency_verdicts": deps})
+
+
+@pytest.fixture()
+def stub_server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _StubHandler)
+    server.requests = []
+    server.author_reply = lambda body: _canned_author_text()
+    server.judge_reply = lambda body: _verdict_from_prompt(body, supported=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server
+    server.shutdown()
+    thread.join(timeout=5)
+
+
+def _git_init(root):
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "e2e@example.test"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "E2E"], cwd=root, check=True)
+
+
+def _prepare(repo, stub_server, monkeypatch):
+    _write_template(repo)
+    _write_contracts(repo)
+    _git_init(repo)
+    port = stub_server.server_address[1]
+    (repo / "llm-profiles.yaml").write_text(
+        f"""author:
+  api_shape: anthropic
+  base_url: http://127.0.0.1:{port}
+  model: stub-author
+  api_key_env: E2E_AUTHOR_KEY
+judge:
+  api_shape: openai
+  base_url: http://127.0.0.1:{port}/v1
+  model: stub-judge
+  api_key_env: E2E_JUDGE_KEY
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("E2E_AUTHOR_KEY", "stub-key-a")
+    monkeypatch.setenv("E2E_JUDGE_KEY", "stub-key-b")
+    con = db.connect(repo)
+    oid, _ = _seed_claimed_author(con)
+    with db.transaction(con):
+        con.execute("UPDATE tasks SET status='queued', worker_id=NULL")
+        con.execute("UPDATE objects SET state='l1_ready' WHERE id=?", (oid,))
+    con.close()
+    return oid
+
+
+def test_e2e_happy_path_promotes_and_commits(repo, stub_server, monkeypatch):
+    oid = _prepare(repo, stub_server, monkeypatch)
+
+    rc = pipeline.main(["l1-run", "--limit", "5", "--max-batches", "5"])
+
+    assert rc == 0
+    con = db.connect(repo)
+    row = con.execute("SELECT state, doc_level FROM objects WHERE id=?", (oid,)).fetchone()
+    assert row["state"] == "applied" and row["doc_level"] == "L1"
+    con.close()
+    assert (repo / "abap_wiki" / "ZTEST" / "program-ZTEST_PROG.md").exists()
+    # both wire shapes were exercised
+    paths = {r["path"] for r in stub_server.requests}
+    assert "/v1/messages" in paths and "/v1/chat/completions" in paths
+    # the author request carried the contract, the addendum and the numbered source
+    author_req = next(r for r in stub_server.requests if r["path"] == "/v1/messages")
+    assert "Headless-mode addendum" in author_req["body"]["system"]
+    user = author_req["body"]["messages"][0]["content"]
+    assert "1  REPORT ztest_prog." in user and "TEMPLATE-MARKER" in user
+    # secrets never leave the profile: header only (the stub saw no key in bodies)
+    assert "stub-key-a" not in json.dumps(author_req["body"])
+    # the batch commit happened in the FIXTURE repo
+    log = subprocess.run(
+        ["git", "log", "--oneline"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout
+    assert "ingest L1 headless batch" in log
+
+
+def test_e2e_revert_then_retry_with_feedback(repo, stub_server, monkeypatch):
+    oid = _prepare(repo, stub_server, monkeypatch)
+    state = {"judge_calls": 0}
+
+    def judge_reply(body):
+        state["judge_calls"] += 1
+        return _verdict_from_prompt(body, supported=state["judge_calls"] > 1)
+
+    stub_server.judge_reply = judge_reply
+
+    rc = pipeline.main(["l1-run", "--limit", "5", "--max-batches", "5"])
+
+    assert rc == 0 and state["judge_calls"] == 2
+    con = db.connect(repo)
+    row = con.execute("SELECT doc_level FROM objects WHERE id=?", (oid,)).fetchone()
+    assert row["doc_level"] == "L1"  # promoted on the second round
+    con.close()
+    author_reqs = [r for r in stub_server.requests if r["path"] == "/v1/messages"]
+    assert len(author_reqs) == 2
+    first = author_reqs[0]["body"]["messages"][0]["content"]
+    second = author_reqs[1]["body"]["messages"][0]["content"]
+    assert "Previous attempt REJECTED" not in first
+    assert "Previous attempt REJECTED" in second  # gate findings injected on retry
+
+
+def test_e2e_broken_author_output_fails_without_promotion(repo, stub_server, monkeypatch):
+    oid = _prepare(repo, stub_server, monkeypatch)
+    stub_server.author_reply = lambda body: "this is not: [valid yaml"
+
+    rc = pipeline.main(["l1-run", "--limit", "5", "--max-batches", "6"])
+
+    assert rc == 1  # failures surface in the exit code
+    con = db.connect(repo)
+    row = con.execute("SELECT doc_level FROM objects WHERE id=?", (oid,)).fetchone()
+    assert row["doc_level"] == "L0"  # fail-closed: never promoted
+    tasks = con.execute(
+        "SELECT status, attempt, max_attempts FROM tasks WHERE object_id=? AND kind='l1_author'",
+        (oid,),
+    ).fetchall()
+    assert all(t["status"] in ("failed", "queued") for t in tasks)
+    con.close()
+
+
+@pytest.mark.skipif(
+    os.environ.get("ABAPWIKI_LIVE_SMOKE") != "1",
+    reason="live smoke: set ABAPWIKI_LIVE_SMOKE=1 plus a real llm-profiles.yaml + keys; never in CI",
+)
+def test_live_smoke_one_object(repo, monkeypatch):
+    """Manual-only (spec 6): one synthetic ZTEST object through REAL endpoints.
+    Profiles come from ABAPWIKI_SMOKE_PROFILES or the real repo root
+    llm-profiles.yaml; the fixture gets the REAL templates AND REAL contracts
+    so the live model sees the true per-type structure and the real analyzer/
+    deepcheck contracts (fake ones would make a real model produce garbage).
+    Runs on demo/synthetic data only."""
+    real_root = Path(__file__).resolve().parents[4]
+    profiles = os.environ.get("ABAPWIKI_SMOKE_PROFILES", str(real_root / "llm-profiles.yaml"))
+    shutil.rmtree(repo / "templates")
+    shutil.copytree(real_root / "templates", repo / "templates")
+    for rel in (headless_l1.ANALYZER_CONTRACT, headless_l1.DEEPCHECK_CONTRACT):
+        dst = repo / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_text((real_root / rel).read_text(encoding="utf-8"), encoding="utf-8")
+    _git_init(repo)
+    con = db.connect(repo)
+    oid, _ = _seed_claimed_author(con)
+    with db.transaction(con):
+        con.execute("UPDATE tasks SET status='queued', worker_id=NULL")
+        con.execute("UPDATE objects SET state='l1_ready' WHERE id=?", (oid,))
+    con.close()
+
+    rc = pipeline.main(["l1-run", "--limit", "1", "--max-batches", "3", "--profiles", profiles])
+
+    assert rc == 0
+    con = db.connect(repo)
+    row = con.execute("SELECT doc_level FROM objects WHERE id=?", (oid,)).fetchone()
+    assert row["doc_level"] == "L1"
+    con.close()

--- a/core/src/test/unit_tests/test_headless_l1.py
+++ b/core/src/test/unit_tests/test_headless_l1.py
@@ -1,0 +1,134 @@
+"""Unit tests for headless_l1 prompt assembly and loop wiring.
+
+What it does: validates the author/judge system prompts (contract body +
+runtime addendum, frontmatter stripped), the author user prompt (metadata +
+template + numbered sources + include resolution + REVERT feedback +
+oversize guard), the judge user prompt (object_slug + pre-rendered
+deepcheck-prompt.txt), and the l1-run CLI registration in pipeline.
+How it works: uses the conftest `repo` fixture (ZTEST_PROG raw source +
+initialized DB); seeds objects/tasks via claims_queue like test_l1_cycle;
+never calls the network (prompt builders are pure I/O on the fixture tree).
+Connections: exercises core/src/tools/headless_l1.py; consumes conftest.py,
+claims_queue, db; registration smoke goes through pipeline.build_parser.
+"""
+
+import json
+
+import claims_queue
+import db
+import headless_l1
+import pytest
+import slugs
+
+RAW = "raw/system-library/ZTEST/Source Code Library/Programmi/ZTEST_PROG/ZTEST_PROG.prog.abap"
+
+
+def _seed_claimed_author(con, run_id="run-h", batch_id="b-h"):
+    cur = con.execute(
+        "INSERT INTO objects (sap_name, sap_type, tadir_object, devclass, is_custom, "
+        "namespace, origin, state, doc_level, slug, raw_source_path, raw_source_status, "
+        "source_hash) VALUES ('ZTEST_PROG', 'program', 'PROG', 'ZTEST', 1, 'Z', 'tadir', "
+        "'l1_ready', 'L0', ?, ?, 'available', '')",
+        (slugs.make_slug("program", "ZTEST_PROG"), RAW),
+    )
+    oid = cur.lastrowid
+    with db.transaction(con):
+        claims_queue.enqueue(con, oid, "l1_author")
+    claimed = claims_queue.claim(con, "l1_author", 1, run_id, run_id=run_id, batch_id=batch_id)
+    return oid, claimed[0]
+
+
+def _write_template(repo):
+    (repo / "templates" / "template-program.md").write_text(
+        "# Template: program\n\n## Executive summary\nTEMPLATE-MARKER\n", encoding="utf-8"
+    )
+
+
+def test_author_system_prompt_contract_plus_addendum(repo):
+    text = headless_l1._author_system(repo)
+    assert "ABAP Analyzer" in text  # contract body present
+    assert "model: inherit" not in text  # frontmatter stripped
+    assert "Headless-mode addendum" in text
+
+
+def test_author_user_prompt_has_metadata_template_and_numbered_source(repo):
+    _write_template(repo)
+    con = db.connect(repo)
+    _, task = _seed_claimed_author(con)
+    prompt = headless_l1._build_author_user(con, repo, task)
+    assert "sap_name: ZTEST_PROG" in prompt and "sap_type: program" in prompt
+    assert "TEMPLATE-MARKER" in prompt
+    assert "1  REPORT ztest_prog." in prompt  # 1-based numbered source lines
+    assert "Previous attempt REJECTED" not in prompt
+    con.close()
+
+
+def test_author_user_prompt_injects_revert_feedback_from_previous_task(repo):
+    """A gate REVERT finishes the old author task and enqueues a NEW one;
+    rejected-claims.json lives in the OLD task dir (cli_loop.py:554). The
+    builder must find it via the DB, not in the current task dir."""
+    _write_template(repo)
+    con = db.connect(repo)
+    oid, old_task = _seed_claimed_author(con)
+    with db.transaction(con):
+        claims_queue.finish(con, old_task["task_id"])  # revert path finishes the old task
+        claims_queue.enqueue(con, oid, "l1_author")  # and enqueues a new one
+    new_task = claims_queue.claim(con, "l1_author", 1, "run-h", run_id="run-h", batch_id="b-h")[0]
+    assert new_task["task_id"] != old_task["task_id"]
+    art = repo / "output" / "runs" / "run-h" / str(old_task["task_id"])
+    art.mkdir(parents=True)
+    (art / "rejected-claims.json").write_text(
+        json.dumps({"reasons": ["S3 too high"], "verdict": None}), encoding="utf-8"
+    )
+    prompt = headless_l1._build_author_user(con, repo, new_task)
+    assert "Previous attempt REJECTED" in prompt and "S3 too high" in prompt
+    con.close()
+
+
+def test_author_user_prompt_missing_template_fails(repo):
+    con = db.connect(repo)
+    _, task = _seed_claimed_author(con)
+    with pytest.raises(headless_l1.TaskPromptError) as exc:
+        headless_l1._build_author_user(con, repo, task)
+    assert "template" in str(exc.value)
+    con.close()
+
+
+def test_author_user_prompt_oversize_guard(repo, monkeypatch):
+    _write_template(repo)
+    con = db.connect(repo)
+    _, task = _seed_claimed_author(con)
+    monkeypatch.setattr(headless_l1, "MAX_PROMPT_CHARS", 50)
+    with pytest.raises(headless_l1.TaskPromptError) as exc:
+        headless_l1._build_author_user(con, repo, task)
+    assert "too large" in str(exc.value)
+    con.close()
+
+
+def test_judge_user_prompt_reads_prepared_prompt_and_slug(repo):
+    con = db.connect(repo)
+    oid, author_task = _seed_claimed_author(con)
+    a_dir = repo / "output" / "runs" / "run-h" / str(author_task["task_id"])
+    a_dir.mkdir(parents=True)
+    (a_dir / "deepcheck-prompt.txt").write_text("RENDERED-CLAIMS CL-001", encoding="utf-8")
+    # enqueue/claim the deepcheck task; NO manual state jump (l1_ready->authored
+    # is not an allowed transition): claim only sets the in-progress state when
+    # the transition is allowed, and the prompt builder does not depend on state.
+    with db.transaction(con):
+        claims_queue.enqueue(con, oid, "l1_deepcheck")
+    dc_task = claims_queue.claim(con, "l1_deepcheck", 1, "run-h", run_id="run-h", batch_id="b-h")[0]
+    prompt = headless_l1._build_judge_user(con, repo, dc_task, "run-h")
+    assert prompt.startswith("object_slug: program-ZTEST_PROG")
+    assert "RENDERED-CLAIMS CL-001" in prompt
+    con.close()
+
+
+def test_judge_user_prompt_missing_prepared_prompt_fails(repo):
+    con = db.connect(repo)
+    oid, _ = _seed_claimed_author(con)
+    with db.transaction(con):
+        claims_queue.enqueue(con, oid, "l1_deepcheck")
+    dc_task = claims_queue.claim(con, "l1_deepcheck", 1, "run-h", run_id="run-h", batch_id="b-h")[0]
+    with pytest.raises(headless_l1.TaskPromptError):
+        headless_l1._build_judge_user(con, repo, dc_task, "run-h")
+    con.close()

--- a/core/src/test/unit_tests/test_headless_l1.py
+++ b/core/src/test/unit_tests/test_headless_l1.py
@@ -44,7 +44,23 @@ def _write_template(repo):
     )
 
 
+def _write_contracts(repo):
+    """Local contract fixtures (same pattern as test_sync_agents._setup): fake
+    analyzer/deepcheck contracts with a frontmatter block to strip."""
+    programs = repo / "core" / "src" / "agentic" / "programs"
+    programs.mkdir(parents=True, exist_ok=True)
+    (programs / "00-abap-analyzer.md").write_text(
+        "---\nmodel: inherit\n---\n\n# ABAP Analyzer\n\nThis is the analyzer contract.\n",
+        encoding="utf-8",
+    )
+    (programs / "00-abap-deepcheck.md").write_text(
+        "---\nmodel: inherit\n---\n\n# ABAP Deepcheck\n\nThis is the deepcheck contract.\n",
+        encoding="utf-8",
+    )
+
+
 def test_author_system_prompt_contract_plus_addendum(repo):
+    _write_contracts(repo)
     text = headless_l1._author_system(repo)
     assert "ABAP Analyzer" in text  # contract body present
     assert "model: inherit" not in text  # frontmatter stripped
@@ -131,4 +147,54 @@ def test_judge_user_prompt_missing_prepared_prompt_fails(repo):
     dc_task = claims_queue.claim(con, "l1_deepcheck", 1, "run-h", run_id="run-h", batch_id="b-h")[0]
     with pytest.raises(headless_l1.TaskPromptError):
         headless_l1._build_judge_user(con, repo, dc_task, "run-h")
+    con.close()
+
+
+def test_collect_source_files_seeds_include_bfs_from_main_not_folder_order(repo):
+    """A per-object folder can hold more than one file; alphabetical order must
+    not decide which text seeds the include BFS (regression: out[0] seeding)."""
+    con = db.connect(repo)
+    prog_dir = repo / "raw/system-library/ZTEST/Source Code Library/Programmi/ZTEST_PROG"
+    # sorts BEFORE ZTEST_PROG.prog.abap and declares an include the main does NOT have
+    (prog_dir / "AAA_NOTES.txt").write_text("INCLUDE ztest_stray.\n", encoding="utf-8")
+    stray_dir = repo / "raw/system-library/ZTEST/Source Code Library/Programmi/ZTEST_STRAY"
+    stray_dir.mkdir(parents=True)
+    (stray_dir / "ZTEST_STRAY.prog.abap").write_text("WRITE 'stray'.\n", encoding="utf-8")
+    with db.transaction(con):
+        con.execute(
+            "INSERT INTO objects (sap_name, sap_type, tadir_object, devclass, is_custom, "
+            "namespace, origin, state, doc_level, slug, raw_source_path, raw_source_status, "
+            "source_hash) VALUES ('ZTEST_STRAY', 'include', 'PROG', 'ZTEST', 1, 'Z', 'tadir', "
+            "'l1_ready', 'L0', ?, 'raw/system-library/ZTEST/Source Code Library/Programmi/"
+            "ZTEST_STRAY/ZTEST_STRAY.prog.abap', 'available', '')",
+            (slugs.make_slug("include", "ZTEST_STRAY"),),
+        )
+    _, task = _seed_claimed_author(con)
+    rels = [rel for rel, _ in headless_l1._collect_source_files(con, repo, task)]
+    assert not any("ZTEST_STRAY" in r for r in rels)
+    con.close()
+
+
+def test_collect_source_files_pulls_declared_includes(repo):
+    con = db.connect(repo)
+    prog_dir = repo / "raw/system-library/ZTEST/Source Code Library/Programmi/ZTEST_PROG"
+    main_path = prog_dir / "ZTEST_PROG.prog.abap"
+    main_path.write_text(
+        main_path.read_text(encoding="utf-8") + "INCLUDE ztest_inc.\n", encoding="utf-8"
+    )
+    inc_dir = repo / "raw/system-library/ZTEST/Source Code Library/Programmi/ZTEST_INC"
+    inc_dir.mkdir(parents=True)
+    (inc_dir / "ZTEST_INC.prog.abap").write_text("WRITE 'inc'.\n", encoding="utf-8")
+    with db.transaction(con):
+        con.execute(
+            "INSERT INTO objects (sap_name, sap_type, tadir_object, devclass, is_custom, "
+            "namespace, origin, state, doc_level, slug, raw_source_path, raw_source_status, "
+            "source_hash) VALUES ('ZTEST_INC', 'include', 'PROG', 'ZTEST', 1, 'Z', 'tadir', "
+            "'l1_ready', 'L0', ?, 'raw/system-library/ZTEST/Source Code Library/Programmi/"
+            "ZTEST_INC/ZTEST_INC.prog.abap', 'available', '')",
+            (slugs.make_slug("include", "ZTEST_INC"),),
+        )
+    _, task = _seed_claimed_author(con)
+    files = headless_l1._collect_source_files(con, repo, task)
+    assert any("ZTEST_INC" in rel for rel, _ in files)
     con.close()

--- a/core/src/test/unit_tests/test_headless_l1.py
+++ b/core/src/test/unit_tests/test_headless_l1.py
@@ -198,3 +198,136 @@ def test_collect_source_files_pulls_declared_includes(repo):
     files = headless_l1._collect_source_files(con, repo, task)
     assert any("ZTEST_INC" in rel for rel, _ in files)
     con.close()
+
+
+def test_l1_run_registered_in_pipeline_parser():
+    import pipeline
+
+    args = pipeline.build_parser().parse_args(
+        ["l1-run", "--package", "ZTEST", "--limit", "3", "--max-batches", "2"]
+    )
+    assert args.cmd == "l1-run" and args.package == "ZTEST"
+    assert args.limit == 3 and args.max_batches == 2
+    assert "l1-run" in headless_l1.COMMANDS
+
+
+def _write_profiles_file(repo):
+    (repo / "llm-profiles.yaml").write_text(
+        "author:\n  api_shape: anthropic\n  base_url: http://127.0.0.1:9\n"
+        "  model: model-a\n  api_key_env: TEST_AUTHOR_KEY\n"
+        "judge:\n  api_shape: openai\n  base_url: http://127.0.0.1:9/v1\n"
+        "  model: model-b\n  api_key_env: TEST_JUDGE_KEY\n",
+        encoding="utf-8",
+    )
+
+
+def _canned_author_yaml_text():
+    # same canned artifact the real pipeline accepts in test_l1_cycle.py
+    import yaml as yamllib
+    from test_l1_cycle import _author_yaml
+
+    return yamllib.safe_dump(_author_yaml(), allow_unicode=True, sort_keys=False)
+
+
+def _canned_verdict_text(root, run_id, object_id, con):
+    author_task = con.execute(
+        "SELECT id FROM tasks WHERE object_id=? AND kind='l1_author' ORDER BY id DESC LIMIT 1",
+        (object_id,),
+    ).fetchone()
+    meta = json.loads(
+        (root / "output/runs" / run_id / str(author_task["id"]) / "deepcheck.meta.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    verd = [
+        {
+            "claim_id": c,
+            "class": "behavior",
+            "verdict": "supported",
+            "confidence": "high",
+            "rationale": "ok",
+        }
+        for c in meta["claim_ids"]
+    ]
+    deps = [
+        {"dep_id": c, "name": "MSEG", "verdict": "confirmed", "confidence": "high"}
+        for c in meta["dep_ids"]
+    ]
+    return json.dumps(
+        {"object_slug": meta["object_slug"], "verdicts": verd, "dependency_verdicts": deps}
+    )
+
+
+def test_run_l1_happy_path_with_mocked_llm(repo, monkeypatch):
+    _write_template(repo)
+    _write_contracts(repo)
+    _write_profiles_file(repo)
+    (repo / ".git").mkdir()  # run_l1's preflight only checks presence; _commit_batch is mocked
+    monkeypatch.setenv("TEST_AUTHOR_KEY", "k1")
+    monkeypatch.setenv("TEST_JUDGE_KEY", "k2")
+    monkeypatch.setattr(headless_l1, "_commit_batch", lambda con, root, batch_id: True)
+    con_seed = db.connect(repo)
+    oid, _task = _seed_claimed_author(con_seed)  # claimed once; recover will release it
+    # un-claim: reset to queued so run_l1's own claim takes it (fresh-queue scenario)
+    with db.transaction(con_seed):
+        con_seed.execute("UPDATE tasks SET status='queued', worker_id=NULL")
+        con_seed.execute("UPDATE objects SET state='l1_ready' WHERE id=?", (oid,))
+    con_seed.close()
+
+    state = {"judge_calls": 0}
+
+    def fake_complete(profile, system, user, **kwargs):
+        if profile.name == "author":
+            return "```yaml\n" + _canned_author_yaml_text() + "```"
+        state["judge_calls"] += 1
+        # the current run_id is not passed to complete(): recover it from the
+        # only physical run dir (artifacts are written under run-headless-<ts>)
+        runs = sorted((repo / "output" / "runs").iterdir())
+        con = db.connect(repo)
+        try:
+            return _canned_verdict_text(repo, runs[-1].name, oid, con)
+        finally:
+            con.close()
+
+    monkeypatch.setattr(headless_l1.llm_client, "complete", fake_complete)
+    rc = headless_l1.run_l1(limit=5, max_batches=3)
+    assert rc == 0
+    con = db.connect(repo)
+    row = con.execute("SELECT state, doc_level FROM objects WHERE id=?", (oid,)).fetchone()
+    assert row["state"] == "applied" and row["doc_level"] == "L1"
+    con.close()
+    assert (repo / "abap_wiki" / "ZTEST" / "program-ZTEST_PROG.md").exists()
+    assert state["judge_calls"] == 1
+
+
+def test_run_l1_llm_failure_consumes_attempt_and_returns_1(repo, monkeypatch):
+    _write_template(repo)
+    _write_contracts(repo)
+    _write_profiles_file(repo)
+    (repo / ".git").mkdir()  # run_l1's preflight only checks presence; _commit_batch is mocked
+    monkeypatch.setenv("TEST_AUTHOR_KEY", "k1")
+    monkeypatch.setenv("TEST_JUDGE_KEY", "k2")
+    monkeypatch.setattr(headless_l1, "_commit_batch", lambda con, root, batch_id: True)
+    con_seed = db.connect(repo)
+    oid, _ = _seed_claimed_author(con_seed)
+    with db.transaction(con_seed):
+        con_seed.execute("UPDATE tasks SET status='queued', worker_id=NULL")
+        con_seed.execute("UPDATE objects SET state='l1_ready' WHERE id=?", (oid,))
+    con_seed.close()
+
+    def fake_complete(profile, system, user, **kwargs):
+        raise headless_l1.llm_client.LLMError("author: LLM call failed after 3 attempt(s)")
+
+    monkeypatch.setattr(headless_l1.llm_client, "complete", fake_complete)
+    rc = headless_l1.run_l1(limit=5, max_batches=5)
+    assert rc == 1  # attempts exhausted -> failures surfaced in the exit code
+    con = db.connect(repo)
+    row = con.execute("SELECT doc_level FROM objects WHERE id=?", (oid,)).fetchone()
+    assert row["doc_level"] == "L0"  # never promoted
+    con.close()
+
+
+def test_run_l1_missing_profiles_is_preflight_error(repo, capsys):
+    rc = headless_l1.run_l1()
+    assert rc == 2
+    assert "llm-profiles" in capsys.readouterr().err

--- a/core/src/test/unit_tests/test_llm_client.py
+++ b/core/src/test/unit_tests/test_llm_client.py
@@ -1,0 +1,84 @@
+"""Unit tests for llm_client (headless L1 runner HTTP client).
+
+What it does: validates profile loading (env-only api keys, same-model warning,
+hard errors), the two wire adapters (Anthropic Messages / OpenAI chat-completions),
+the deterministic text helpers (code-fence strip, frontmatter strip), and
+complete() retry/truncation/secret-safety - all without network (fake transport).
+How it works: builds profiles from tmp_path YAML files + plain dict env; fake
+transports return canned (status, payload) tuples and record calls; a recording
+sleeper asserts the backoff sequence.
+Connections: exercises core/src/tools/llm_client.py; no fixture dependencies
+beyond tmp_path (block_network guards against accidental real HTTP).
+"""
+
+import llm_client  # noqa: E402
+import pytest
+
+
+def _write_profiles(tmp_path, author_model="model-a", judge_model="model-b"):
+    p = tmp_path / "llm-profiles.yaml"
+    p.write_text(
+        f"""author:
+  api_shape: anthropic
+  base_url: https://api.example.test
+  model: {author_model}
+  api_key_env: TEST_AUTHOR_KEY
+  max_tokens: 1234
+judge:
+  api_shape: openai
+  base_url: http://127.0.0.1:9/v1
+  model: {judge_model}
+  api_key_env: TEST_JUDGE_KEY
+""",
+        encoding="utf-8",
+    )
+    return p
+
+
+ENV = {"TEST_AUTHOR_KEY": "sk-author-secret", "TEST_JUDGE_KEY": "sk-judge-secret"}
+
+
+def test_load_profiles_ok(tmp_path):
+    author, judge, warnings = llm_client.load_profiles(_write_profiles(tmp_path), ENV)
+    assert author.name == "author" and author.api_shape == "anthropic"
+    assert author.api_key == "sk-author-secret" and author.max_tokens == 1234
+    assert judge.name == "judge" and judge.api_shape == "openai"
+    assert judge.max_tokens == llm_client.DEFAULT_MAX_TOKENS
+    assert warnings == []
+
+
+def test_load_profiles_same_model_warns_but_accepts(tmp_path):
+    path = _write_profiles(tmp_path, author_model="same", judge_model="same")
+    author, judge, warnings = llm_client.load_profiles(path, ENV)
+    assert author.model == judge.model == "same"
+    assert len(warnings) == 1 and "same model" in warnings[0]
+
+
+def test_load_profiles_missing_file_points_to_example(tmp_path):
+    with pytest.raises(llm_client.ProfileError) as exc:
+        llm_client.load_profiles(tmp_path / "nope.yaml", ENV)
+    assert "llm-profiles.yaml.example" in str(exc.value)
+
+
+def test_load_profiles_missing_env_var_raises(tmp_path):
+    with pytest.raises(llm_client.ProfileError) as exc:
+        llm_client.load_profiles(_write_profiles(tmp_path), {"TEST_AUTHOR_KEY": "x"})
+    assert "TEST_JUDGE_KEY" in str(exc.value)
+
+
+def test_load_profiles_bad_shape_raises(tmp_path):
+    p = tmp_path / "llm-profiles.yaml"
+    p.write_text(
+        "author:\n  api_shape: grpc\n  base_url: x\n  model: m\n  api_key_env: TEST_AUTHOR_KEY\n"
+        "judge:\n  api_shape: openai\n  base_url: x\n  model: m2\n  api_key_env: TEST_JUDGE_KEY\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(llm_client.ProfileError) as exc:
+        llm_client.load_profiles(p, ENV)
+    assert "api_shape" in str(exc.value)
+
+
+def test_profile_repr_never_leaks_the_key(tmp_path):
+    author, judge, _ = llm_client.load_profiles(_write_profiles(tmp_path), ENV)
+    assert "sk-author-secret" not in repr(author) + str(author)
+    assert "sk-judge-secret" not in repr(judge) + str(judge)

--- a/core/src/test/unit_tests/test_llm_client.py
+++ b/core/src/test/unit_tests/test_llm_client.py
@@ -160,3 +160,84 @@ def test_strip_frontmatter():
     text = "---\nname: x\nmodel: y\n---\n\n# Body\nrest"
     assert llm_client.strip_frontmatter(text) == "# Body\nrest"
     assert llm_client.strip_frontmatter("# No fm\nbody") == "# No fm\nbody"
+
+
+def test_complete_retries_on_429_with_backoff(tmp_path):
+    profile = _author_profile(tmp_path)
+    calls, sleeps = [], []
+    responses = [
+        (429, {}),
+        (503, {}),
+        (200, {"content": [{"type": "text", "text": "done"}], "stop_reason": "end_turn"}),
+    ]
+
+    def transport(url, headers, body, timeout):
+        calls.append(url)
+        return responses[len(calls) - 1]
+
+    out = llm_client.complete(profile, "S", "U", transport=transport, sleeper=sleeps.append)
+    assert out == "done"
+    assert len(calls) == 3 and sleeps == [1, 2]
+
+
+def test_complete_gives_up_after_max_attempts(tmp_path):
+    profile = _author_profile(tmp_path)
+
+    def transport(url, headers, body, timeout):
+        return 503, {}
+
+    with pytest.raises(llm_client.LLMError) as exc:
+        llm_client.complete(profile, "S", "U", transport=transport, sleeper=lambda s: None)
+    assert "HTTP 503" in str(exc.value)
+    assert "sk-author-secret" not in str(exc.value)
+
+
+def test_complete_does_not_retry_client_errors(tmp_path):
+    profile = _author_profile(tmp_path)
+    calls = []
+
+    def transport(url, headers, body, timeout):
+        calls.append(1)
+        return 401, {}
+
+    with pytest.raises(llm_client.LLMError):
+        llm_client.complete(profile, "S", "U", transport=transport, sleeper=lambda s: None)
+    assert len(calls) == 1
+
+
+def test_complete_truncated_output_raises(tmp_path):
+    profile = _author_profile(tmp_path)
+
+    def transport(url, headers, body, timeout):
+        return 200, {"content": [{"type": "text", "text": "cut"}], "stop_reason": "max_tokens"}
+
+    with pytest.raises(llm_client.LLMError) as exc:
+        llm_client.complete(profile, "S", "U", transport=transport, sleeper=lambda s: None)
+    assert "truncated" in str(exc.value)
+
+
+def test_complete_network_error_is_retried_and_safe(tmp_path):
+    import urllib.error
+
+    profile = _author_profile(tmp_path)
+    calls = []
+
+    def transport(url, headers, body, timeout):
+        calls.append(1)
+        raise urllib.error.URLError("boom sk-author-secret")
+
+    with pytest.raises(llm_client.LLMError) as exc:
+        llm_client.complete(profile, "S", "U", transport=transport, sleeper=lambda s: None)
+    assert len(calls) == llm_client.MAX_ATTEMPTS
+    assert "sk-author-secret" not in str(exc.value)  # only the exception CLASS is reported
+
+
+def test_complete_empty_completion_raises(tmp_path):
+    profile = _author_profile(tmp_path)
+
+    def transport(url, headers, body, timeout):
+        return 200, {"content": [], "stop_reason": "end_turn"}
+
+    with pytest.raises(llm_client.LLMError) as exc:
+        llm_client.complete(profile, "S", "U", transport=transport, sleeper=lambda s: None)
+    assert "empty" in str(exc.value)

--- a/core/src/test/unit_tests/test_llm_client.py
+++ b/core/src/test/unit_tests/test_llm_client.py
@@ -82,3 +82,81 @@ def test_profile_repr_never_leaks_the_key(tmp_path):
     author, judge, _ = llm_client.load_profiles(_write_profiles(tmp_path), ENV)
     assert "sk-author-secret" not in repr(author) + str(author)
     assert "sk-judge-secret" not in repr(judge) + str(judge)
+
+
+def _author_profile(tmp_path):
+    return llm_client.load_profiles(_write_profiles(tmp_path), ENV)[0]
+
+
+def _judge_profile(tmp_path):
+    return llm_client.load_profiles(_write_profiles(tmp_path), ENV)[1]
+
+
+def test_build_request_anthropic(tmp_path):
+    url, headers, body = llm_client.build_request(_author_profile(tmp_path), "SYS", "USER")
+    assert url == "https://api.example.test/v1/messages"
+    assert headers["x-api-key"] == "sk-author-secret"
+    assert headers["anthropic-version"] == "2023-06-01"
+    assert body == {
+        "model": "model-a",
+        "max_tokens": 1234,
+        "system": "SYS",
+        "messages": [{"role": "user", "content": "USER"}],
+    }
+
+
+def test_build_request_openai(tmp_path):
+    url, headers, body = llm_client.build_request(_judge_profile(tmp_path), "SYS", "USER")
+    assert url == "http://127.0.0.1:9/v1/chat/completions"
+    assert headers["authorization"] == "Bearer sk-judge-secret"
+    assert body["messages"] == [
+        {"role": "system", "content": "SYS"},
+        {"role": "user", "content": "USER"},
+    ]
+
+
+def test_parse_response_anthropic(tmp_path):
+    res = llm_client.parse_response(
+        _author_profile(tmp_path),
+        {"content": [{"type": "text", "text": "hello"}], "stop_reason": "end_turn"},
+    )
+    assert res.text == "hello" and res.truncated is False
+
+
+def test_parse_response_anthropic_truncated(tmp_path):
+    res = llm_client.parse_response(
+        _author_profile(tmp_path),
+        {"content": [{"type": "text", "text": "cut"}], "stop_reason": "max_tokens"},
+    )
+    assert res.truncated is True
+
+
+def test_parse_response_openai(tmp_path):
+    res = llm_client.parse_response(
+        _judge_profile(tmp_path),
+        {"choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}]},
+    )
+    assert res.text == "hi" and res.truncated is False
+
+
+def test_parse_response_openai_truncated(tmp_path):
+    res = llm_client.parse_response(
+        _judge_profile(tmp_path),
+        {"choices": [{"message": {"content": "cut"}, "finish_reason": "length"}]},
+    )
+    assert res.truncated is True
+
+
+def test_strip_code_fences_variants():
+    assert llm_client.strip_code_fences("plain: 1") == "plain: 1"
+    assert llm_client.strip_code_fences("```yaml\nkey: v\n```") == "key: v"
+    assert llm_client.strip_code_fences('```json\n{"a": 1}\n```') == '{"a": 1}'
+    assert llm_client.strip_code_fences("  ```\nx\n```  ") == "x"
+    # unbalanced fence: leave untouched (fail visible downstream, not silent edit)
+    assert llm_client.strip_code_fences("```yaml\nkey: v").startswith("```")
+
+
+def test_strip_frontmatter():
+    text = "---\nname: x\nmodel: y\n---\n\n# Body\nrest"
+    assert llm_client.strip_frontmatter(text) == "# Body\nrest"
+    assert llm_client.strip_frontmatter("# No fm\nbody") == "# No fm\nbody"

--- a/core/src/test/unit_tests/test_llm_client.py
+++ b/core/src/test/unit_tests/test_llm_client.py
@@ -13,7 +13,7 @@ beyond tmp_path (block_network guards against accidental real HTTP).
 
 import json
 
-import llm_client  # noqa: E402
+import llm_client
 import pytest
 
 

--- a/core/src/test/unit_tests/test_llm_client.py
+++ b/core/src/test/unit_tests/test_llm_client.py
@@ -11,6 +11,8 @@ Connections: exercises core/src/tools/llm_client.py; no fixture dependencies
 beyond tmp_path (block_network guards against accidental real HTTP).
 """
 
+import json
+
 import llm_client  # noqa: E402
 import pytest
 
@@ -241,3 +243,18 @@ def test_complete_empty_completion_raises(tmp_path):
     with pytest.raises(llm_client.LLMError) as exc:
         llm_client.complete(profile, "S", "U", transport=transport, sleeper=lambda s: None)
     assert "empty" in str(exc.value)
+
+
+def test_complete_malformed_200_body_is_retried_and_safe(tmp_path):
+    profile = _author_profile(tmp_path)
+    calls = []
+
+    def transport(url, headers, body, timeout):
+        calls.append(1)
+        raise json.JSONDecodeError("Expecting value", "sk-author-secret-body", 0)
+
+    with pytest.raises(llm_client.LLMError) as exc:
+        llm_client.complete(profile, "S", "U", transport=transport, sleeper=lambda s: None)
+    assert len(calls) == llm_client.MAX_ATTEMPTS
+    assert "JSONDecodeError" in str(exc.value)
+    assert "sk-author-secret-body" not in str(exc.value)

--- a/core/src/tools/headless_l1.py
+++ b/core/src/tools/headless_l1.py
@@ -110,9 +110,10 @@ def _collect_source_files(con, root: Path, task: dict) -> list[tuple[str, str]]:
             continue
         seen_paths.add(entry["path"])
         out.append((entry["path"], p.read_text(encoding="utf-8", errors="replace")))
-    if (task["sap_type"] or "") == "program" and out:
+    if (task["sap_type"] or "") == "program":
+        main_text = main.read_text(encoding="utf-8", errors="replace")
         seen_objs = {(task["sap_name"] or "").upper()}
-        queue = list(sources.extract_includes(out[0][1]))
+        queue = list(sources.extract_includes(main_text))
         while queue:
             up = queue.pop(0).upper()
             if up in seen_objs:

--- a/core/src/tools/headless_l1.py
+++ b/core/src/tools/headless_l1.py
@@ -24,8 +24,15 @@ Doc: core/docs/15-headless-l1-runner.md.
 
 from __future__ import annotations
 
+import json
+import os
+import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
+import claims_queue
+import cli_loop
+import db
 import llm_client
 import sources
 
@@ -204,3 +211,190 @@ def _build_judge_user(con, root: Path, task: dict, run_id: str) -> str:
     if not prompt_path.exists():
         raise TaskPromptError(f"deepcheck prompt not found: {prompt_path.name}")
     return f"object_slug: {task['slug']}\n\n" + prompt_path.read_text(encoding="utf-8")
+
+
+def _fail_author(con, task: dict, message: str) -> None:
+    """Consumes an attempt and resets the object (mirrors the --fail branch of
+    the submit-author CLI handler)."""
+    with db.transaction(con):
+        claims_queue.fail(con, task["task_id"], message[:300])
+        db.set_state(con, task["object_id"], "l1_ready")
+
+
+def _process_author(con, root: Path, profile, task: dict, run_id: str, batch_id: str) -> bool:
+    try:
+        user = _build_author_user(con, root, task)
+        text = llm_client.complete(profile, _author_system(root), user)
+    except (TaskPromptError, llm_client.LLMError) as exc:
+        print(f"  author {task['sap_name']}: FAILED ({exc})")
+        _fail_author(con, task, str(exc))
+        return False
+    art_dir = root / "output" / "runs" / run_id / str(task["task_id"])
+    art_dir.mkdir(parents=True, exist_ok=True)
+    (art_dir / "author.yaml").write_text(
+        llm_client.strip_code_fences(text) + "\n", encoding="utf-8"
+    )
+    out = cli_loop.submit_author(con, task["task_id"], run_id=run_id, batch_id=batch_id)
+    if out.get("ok"):
+        print(f"  author {task['sap_name']}: ok")
+        return True
+    print(f"  author {task['sap_name']}: rejected ({'; '.join(out.get('errors') or [])[:160]})")
+    return False
+
+
+def _process_judge(con, root: Path, profile, task: dict, run_id: str, batch_id: str) -> str:
+    try:
+        user = _build_judge_user(con, root, task, run_id)
+        text = llm_client.complete(profile, _judge_system(root), user)
+        verdict_dir = root / "output" / "runs" / run_id / str(task["task_id"])
+        verdict_dir.mkdir(parents=True, exist_ok=True)
+        (verdict_dir / "deepcheck.json").write_text(
+            llm_client.strip_code_fences(text) + "\n", encoding="utf-8"
+        )
+    except (TaskPromptError, llm_client.LLMError) as exc:
+        # no verdict file written: submit_verdict evaluates fail-closed (BLOCKED)
+        print(f"  judge {task['sap_name']}: LLM failed ({exc}); fail-closed verdict")
+    out = cli_loop.submit_verdict(con, task["task_id"], run_id=run_id, batch_id=batch_id)
+    outcome = out.get("outcome", "blocked")
+    print(f"  judge {task['sap_name']}: {outcome}")
+    return outcome
+
+
+def _commit_batch(con, root: Path, batch_id: str) -> bool:
+    """Per-batch commit (rule 11), mirroring the git-commit CLI handler:
+    log.md rebuilt and state dump exported BEFORE staging."""
+    import gitops
+    import oplog
+
+    oplog.rebuild(con)
+    gitops.export_state_dump(root)
+    res = gitops.commit_batch(root, f"ingest L1 headless batch {batch_id}")
+    if res.get("blocked") == "secrets":
+        print("git-commit: BLOCKED - plaintext secrets in the staged content", file=sys.stderr)
+        for off in res.get("offenders", []):
+            print(f"  {off}", file=sys.stderr)
+        return False
+    sha = res.get("sha") or ""
+    if sha and batch_id:
+        with db.transaction(con):
+            con.execute("UPDATE batches SET git_commit_sha=? WHERE batch_id=?", (sha, batch_id))
+    print(f"  git-commit: committed={res.get('committed')} sha={sha[:8] if sha else '(none)'}")
+    return True
+
+
+def _open_l1_tasks(con, package: str) -> int:
+    q = (
+        "SELECT COUNT(*) FROM tasks t JOIN objects o ON o.id=t.object_id "
+        "WHERE t.kind IN ('l1_author','l1_deepcheck','l1_apply') "
+        "AND t.status IN ('queued','claimed')"
+    )
+    params: list = []
+    if package:
+        q += " AND o.devclass=?"
+        params.append(package)
+    return con.execute(q, params).fetchone()[0]
+
+
+def run_l1(
+    *, package: str = "", limit: int = 10, max_batches: int = 20, profiles_path: str = ""
+) -> int:
+    """Headless L1 loop: batches until the queue drains or max_batches.
+    Exit codes: 0 = drained with no hard failures; 1 = open work or failures
+    remain (cron/CI-friendly); 2 = preflight/config error (nothing touched)."""
+    root = db.repo_root()
+    prof_path = Path(profiles_path) if profiles_path else root / "llm-profiles.yaml"
+    try:
+        author_p, judge_p, warnings = llm_client.load_profiles(prof_path, os.environ)
+    except llm_client.ProfileError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    for w in warnings:
+        print(f"WARNING: {w}")
+    if not (root / ".git").exists():
+        print(
+            "ERROR: not a git repository: the per-batch commit (rule 11) needs git.",
+            file=sys.stderr,
+        )
+        return 2
+    for rel in (ANALYZER_CONTRACT, DEEPCHECK_CONTRACT):
+        if not (root / rel).exists():
+            print(f"ERROR: canonical contract missing: {rel}", file=sys.stderr)
+            return 2
+    print(
+        f"l1-run: author={author_p.model} ({author_p.api_shape}), "
+        f"judge={judge_p.model} ({judge_p.api_shape})"
+    )
+    ts = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    run_id = f"run-headless-{ts}"
+    con = db.connect()
+    failures = 0
+    try:
+        for n in range(1, max_batches + 1):
+            batch_id = f"b-{ts}-{n:03d}"
+            print(f"== l1-run batch {n}/{max_batches} ({run_id} / {batch_id})")
+            cli_loop.recover(con)  # spec 4: always, at the start of every batch
+            authors = claims_queue.claim(
+                con,
+                "l1_author",
+                limit,
+                run_id,
+                run_id=run_id,
+                batch_id=batch_id,
+                package=package or None,
+            )
+            for t in authors:
+                if not _process_author(con, root, author_p, t, run_id, batch_id):
+                    failures += 1
+            judges = claims_queue.claim(
+                con,
+                "l1_deepcheck",
+                limit,
+                run_id,
+                run_id=run_id,
+                batch_id=batch_id,
+                package=package or None,
+            )
+            for t in judges:
+                _process_judge(con, root, judge_p, t, run_id, batch_id)
+            if not authors and not judges:
+                print("l1-run: queue drained, nothing left to do")
+                break
+            applied = cli_loop.apply_batch(
+                con, run_id=run_id, batch_id=batch_id, limit=max(limit * 2, 50)
+            )
+            print(f"  apply: {json.dumps(applied)}")
+            cli_loop.project(con)
+            import export_excel
+
+            export_excel.export()
+            if not _commit_batch(con, root, batch_id):
+                failures += 1
+                break
+        remaining = _open_l1_tasks(con, package)
+        print(f"l1-run: done (open L1 tasks: {remaining}, hard failures this run: {failures})")
+        return 0 if remaining == 0 and failures == 0 else 1
+    finally:
+        con.close()
+
+
+def register(sub) -> None:
+    sp = sub.add_parser(
+        "l1-run",
+        help="Headless L1 loop: author+judge via direct LLM API calls "
+        "(no chat runner). Config: llm-profiles.yaml",
+    )
+    sp.add_argument("--package", default="", help="Limit to a single devclass")
+    sp.add_argument("--limit", type=int, default=10, help="Tasks claimed per batch")
+    sp.add_argument("--max-batches", type=int, default=20, dest="max_batches")
+    sp.add_argument(
+        "--profiles", default="", help="Profiles file (default: <repo>/llm-profiles.yaml)"
+    )
+
+
+def dispatch(args) -> int:
+    return run_l1(
+        package=args.package,
+        limit=args.limit,
+        max_batches=args.max_batches,
+        profiles_path=args.profiles,
+    )

--- a/core/src/tools/headless_l1.py
+++ b/core/src/tools/headless_l1.py
@@ -1,0 +1,205 @@
+"""Headless L1 runner: the batch loop behind `pipeline.py l1-run`.
+
+What it does: runs the whole L1 loop (author + adversarial judge) via direct
+single-shot LLM API calls - no chat runner, no VS Code - so L1 can run from
+cron/CI. A fourth door into the same pipeline: contracts, gate, state machine
+and validation are the existing ones, unchanged.
+How it works: per batch it drives the SAME deterministic commands the chat
+skill uses (claim -> submit-author -> claim deepcheck -> submit-verdict ->
+apply -> project -> commit) through their existing functions; the only new
+part is who produces author.yaml / deepcheck.json: prompt builders assemble
+system (canonical contract body + runtime addendum, contract file untouched)
+and user (task metadata + template + numbered raw sources + REVERT feedback
+for the author; object_slug + pre-rendered deepcheck-prompt.txt for the
+judge), and llm_client performs one POST per artifact. One run_id per
+invocation so re-claims reuse the same artifact dir (retry feedback works).
+Fail-closed inherited: invalid artifacts are rejected by submit-author /
+submit-verdict exactly as with chat runners. Never logs keys or prompt
+bodies (customer code): only counts, names, outcomes.
+Connections: imports llm_client, claims_queue, cli_loop, db, sources,
+export_excel, gitops, oplog; registered by pipeline.py (_register_phase2 +
+COMMANDS dispatch). Config: llm-profiles.yaml (see llm-profiles.yaml.example).
+Doc: core/docs/15-headless-l1-runner.md.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import llm_client
+import sources
+
+COMMANDS = {"l1-run"}
+ANALYZER_CONTRACT = "core/src/agentic/programs/00-abap-analyzer.md"
+DEEPCHECK_CONTRACT = "core/src/agentic/programs/00-abap-deepcheck.md"
+MAX_PROMPT_CHARS = 400_000
+
+AUTHOR_ADDENDUM = """
+## Headless-mode addendum (this run only)
+
+You are running WITHOUT tools: you cannot read or write files. Everything the
+contract tells you to read (template, examples, raw sources) is already
+included below in this prompt.
+- Do NOT try to read or write any file.
+- Emit ONLY the YAML document of the analysis as your entire reply: no
+  markdown code fences, no summary line, no prose before or after.
+- The numbers prefixed to each source line are the 1-based physical line
+  numbers of the raw file: use exactly them in `evidence` and `line` fields.
+"""
+
+JUDGE_ADDENDUM = """
+## Headless-mode addendum (this run only)
+
+You are running WITHOUT tools: the rendered prompt (claims, dependencies and
+evidence lines) is already included below.
+- Emit ONLY the JSON verdict object as your entire reply: no markdown code
+  fences, no prose before or after.
+- Use the `object_slug` given below in your verdict.
+"""
+
+
+class TaskPromptError(RuntimeError):
+    """Deterministic prompt-assembly failure (missing template/source/prompt):
+    the task is failed WITHOUT spending an LLM call."""
+
+
+def _safe_repo_path(root: Path, rel: str) -> Path | None:
+    """Fail-closed containment for DB-sourced relative paths (mirrors
+    cli_loop._safe_repo_path / pipeline._safe_raw_path): None if the resolved
+    path escapes the repo root."""
+    if not rel:
+        return None
+    try:
+        candidate = (root / rel).resolve()
+    except (OSError, ValueError):
+        return None
+    if not candidate.is_relative_to(root.resolve()):
+        return None
+    return candidate
+
+
+def _numbered(text: str) -> str:
+    return "\n".join(f"{i}  {line}" for i, line in enumerate(text.splitlines(), 1))
+
+
+def _read_contract(root: Path, rel: str, addendum: str) -> str:
+    return llm_client.strip_frontmatter((root / rel).read_text(encoding="utf-8")) + addendum
+
+
+def _author_system(root: Path) -> str:
+    return _read_contract(root, ANALYZER_CONTRACT, AUTHOR_ADDENDUM)
+
+
+def _judge_system(root: Path) -> str:
+    return _read_contract(root, DEEPCHECK_CONTRACT, JUDGE_ADDENDUM)
+
+
+def _collect_source_files(con, root: Path, task: dict) -> list[tuple[str, str]]:
+    """(rel_path, text) for every file the author must see: the object's frozen
+    source set (sources.build_source_set) plus, for programs, the transitive
+    include sources resolved from the DB (mirrors cli_loop._include_source_text:
+    deterministic, 'available' only, fail-closed containment, cycle-safe)."""
+    main = _safe_repo_path(root, task["raw_source_path"])
+    if main is None or not main.exists():
+        raise TaskPromptError(f"raw source not available: {task['raw_source_path']}")
+    out: list[tuple[str, str]] = []
+    seen_paths: set[str] = set()
+    for entry in sources.build_source_set(main, object_name=task["sap_name"]):
+        p = _safe_repo_path(root, entry["path"]) or Path(entry["path"])
+        if not p.exists() or entry["path"] in seen_paths:
+            continue
+        seen_paths.add(entry["path"])
+        out.append((entry["path"], p.read_text(encoding="utf-8", errors="replace")))
+    if (task["sap_type"] or "") == "program" and out:
+        seen_objs = {(task["sap_name"] or "").upper()}
+        queue = list(sources.extract_includes(out[0][1]))
+        while queue:
+            up = queue.pop(0).upper()
+            if up in seen_objs:
+                continue
+            seen_objs.add(up)
+            row = con.execute(
+                "SELECT raw_source_path, raw_source_status FROM objects "
+                "WHERE UPPER(sap_name)=? ORDER BY id LIMIT 1",
+                (up,),
+            ).fetchone()
+            if (
+                row is None
+                or (row["raw_source_status"] or "") != "available"
+                or not row["raw_source_path"]
+            ):
+                continue
+            p = _safe_repo_path(root, row["raw_source_path"])
+            if p is None or not p.exists() or row["raw_source_path"] in seen_paths:
+                continue
+            seen_paths.add(row["raw_source_path"])
+            text = p.read_text(encoding="utf-8", errors="replace")
+            out.append((row["raw_source_path"], text))
+            queue.extend(sources.extract_includes(text))
+    return out
+
+
+def _previous_feedback(con, root: Path, task: dict) -> str:
+    """Gate findings of the object's previous REJECTED attempt, if any. A gate
+    REVERT finishes the old author task and enqueues a NEW one, so
+    rejected-claims.json lives in the OLD task's artifact dir (possibly under
+    an older run_id): resolve previous author task ids from the DB and glob
+    across runs, newest first."""
+    rows = con.execute(
+        "SELECT id FROM tasks WHERE object_id=? AND kind='l1_author' AND id != ? ORDER BY id DESC",
+        (task["object_id"], task["task_id"]),
+    ).fetchall()
+    for r in rows:
+        hits = sorted(root.glob(f"output/runs/*/{r['id']}/rejected-claims.json"))
+        if hits:
+            return hits[-1].read_text(encoding="utf-8")
+    return ""
+
+
+def _build_author_user(con, root: Path, task: dict) -> str:
+    template_path = root / "templates" / f"template-{task['sap_type']}.md"
+    if not template_path.exists():
+        raise TaskPromptError(f"template missing: templates/{template_path.name}")
+    parts = [
+        "## Task",
+        f"sap_name: {task['sap_name']}",
+        f"sap_type: {task['sap_type']}",
+        f"devclass: {task['devclass']}",
+        f"raw_source_path: {task['raw_source_path']}",
+        f"attempt: {task['attempt']}",
+        "",
+        f"## Template (templates/{template_path.name})",
+        template_path.read_text(encoding="utf-8"),
+    ]
+    feedback = _previous_feedback(con, root, task)
+    if feedback:
+        parts += [
+            "",
+            "## Previous attempt REJECTED by the adversarial gate",
+            "Fix the issues below; do not repeat claims the evidence does not support.",
+            feedback,
+        ]
+    for rel, text in _collect_source_files(con, root, task):
+        parts += ["", f"## Source file: {rel} ({len(text.splitlines())} lines)", _numbered(text)]
+    prompt = "\n".join(parts)
+    if len(prompt) > MAX_PROMPT_CHARS:
+        raise TaskPromptError(
+            f"assembled prompt too large ({len(prompt)} chars > {MAX_PROMPT_CHARS}); "
+            "analyze this object with a chat runner instead"
+        )
+    return prompt
+
+
+def _build_judge_user(con, root: Path, task: dict, run_id: str) -> str:
+    author_task = con.execute(
+        "SELECT id FROM tasks WHERE object_id=? AND kind='l1_author' ORDER BY id DESC LIMIT 1",
+        (task["object_id"],),
+    ).fetchone()
+    if author_task is None:
+        raise TaskPromptError(f"no author task found for object {task['sap_name']}")
+    prompt_path = (
+        root / "output" / "runs" / run_id / str(author_task["id"]) / "deepcheck-prompt.txt"
+    )
+    if not prompt_path.exists():
+        raise TaskPromptError(f"deepcheck prompt not found: {prompt_path.name}")
+    return f"object_slug: {task['slug']}\n\n" + prompt_path.read_text(encoding="utf-8")

--- a/core/src/tools/llm_client.py
+++ b/core/src/tools/llm_client.py
@@ -18,6 +18,10 @@ in llm-profiles.yaml.example. Doc: core/docs/15-headless-l1-runner.md.
 
 from __future__ import annotations
 
+import json
+import time
+import urllib.error
+import urllib.request
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -187,3 +191,58 @@ def strip_frontmatter(text: str) -> str:
         if lines[i].strip() == "---":
             return "\n".join(lines[i + 1 :]).lstrip("\n")
     return text
+
+
+def _urllib_transport(url: str, headers: dict, body: dict, timeout: int) -> tuple[int, dict]:
+    """Default transport: one POST, JSON in/out. HTTP error bodies are drained
+    but never surfaced (they may echo the prompt, i.e. customer code)."""
+    req = urllib.request.Request(
+        url, data=json.dumps(body).encode("utf-8"), headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        exc.read()
+        return exc.code, {}
+
+
+def complete(
+    profile: LLMProfile,
+    system: str,
+    user: str,
+    *,
+    transport=None,
+    sleeper=time.sleep,
+) -> str:
+    """Single-shot completion with bounded retry (429/5xx/network, exponential
+    backoff 1s/2s). Raises LLMError on exhaustion, non-retryable HTTP status,
+    truncated or empty output. Error messages carry only profile name, HTTP
+    status or exception class name: never the api key, prompt or response."""
+    transport = transport or _urllib_transport
+    url, headers, body = build_request(profile, system, user)
+    last = "no attempt made"
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        status: int | None
+        try:
+            status, payload = transport(url, headers, body, profile.timeout_sec)
+        except (urllib.error.URLError, OSError, TimeoutError) as exc:
+            status, payload = None, {}
+            last = f"network error: {exc.__class__.__name__}"
+        if status == 200:
+            result = parse_response(profile, payload)
+            if result.truncated:
+                raise LLMError(
+                    f"{profile.name}: completion truncated "
+                    f"(stop_reason={result.stop_reason}); raise max_tokens"
+                )
+            if not result.text.strip():
+                raise LLMError(f"{profile.name}: empty completion from the endpoint")
+            return result.text
+        if status is not None:
+            last = f"HTTP {status}"
+            if status not in RETRY_STATUS:
+                break
+        if attempt < MAX_ATTEMPTS:
+            sleeper(2 ** (attempt - 1))
+    raise LLMError(f"{profile.name}: LLM call failed after {MAX_ATTEMPTS} attempt(s): {last}")

--- a/core/src/tools/llm_client.py
+++ b/core/src/tools/llm_client.py
@@ -1,0 +1,112 @@
+"""HTTP client for the headless L1 runner: LLM profiles + wire adapters.
+
+What it does: loads and validates the author/judge LLM profiles
+(llm-profiles.yaml, api keys resolved from environment variables only) and
+performs single-shot chat completions against Anthropic-Messages- or
+OpenAI-chat-completions-shaped endpoints via stdlib urllib (no new deps).
+How it works: load_profiles parses the YAML and returns (author, judge,
+warnings), failing fast with ProfileError on hard errors; build_request /
+parse_response translate one (system, user) exchange to/from each wire shape;
+complete() adds bounded retry with exponential backoff on 429/5xx/network
+errors and fails on truncated or empty output; strip_code_fences /
+strip_frontmatter are deterministic text helpers. Pure functions plus an
+injectable transport/sleeper: unit-testable without network. Error messages
+and reprs never carry api keys or prompt/response bodies (customer code).
+Connections: imported by headless_l1 (orchestrator); user config documented
+in llm-profiles.yaml.example. Doc: core/docs/15-headless-l1-runner.md.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+API_SHAPES = ("anthropic", "openai")
+DEFAULT_MAX_TOKENS = 16000
+DEFAULT_TIMEOUT_SEC = 600
+RETRY_STATUS = {429, 500, 502, 503, 504}
+MAX_ATTEMPTS = 3
+
+
+class ProfileError(ValueError):
+    """Hard configuration error: the runner must not start."""
+
+
+class LLMError(RuntimeError):
+    """LLM call failure (network, HTTP, truncated/empty output). Message is
+    safe to log: never carries the api key nor prompt/response bodies."""
+
+
+@dataclass(frozen=True)
+class LLMProfile:
+    name: str
+    api_shape: str
+    base_url: str
+    model: str
+    api_key_env: str
+    api_key: str = field(repr=False, default="")
+    max_tokens: int = DEFAULT_MAX_TOKENS
+    timeout_sec: int = DEFAULT_TIMEOUT_SEC
+
+
+@dataclass(frozen=True)
+class LLMResult:
+    text: str
+    stop_reason: str
+    truncated: bool
+
+
+def _build_profile(name: str, raw: dict, env: Mapping[str, str]) -> LLMProfile:
+    if not isinstance(raw, dict):
+        raise ProfileError(f"profile '{name}' must be a mapping")
+    shape = str(raw.get("api_shape") or "").strip()
+    if shape not in API_SHAPES:
+        raise ProfileError(f"{name}: api_shape must be one of {API_SHAPES}, got {shape!r}")
+    base_url = str(raw.get("base_url") or "").strip()
+    model = str(raw.get("model") or "").strip()
+    key_env = str(raw.get("api_key_env") or "").strip()
+    if not base_url or not model or not key_env:
+        raise ProfileError(f"{name}: base_url, model and api_key_env are all required")
+    api_key = str(env.get(key_env) or "").strip()
+    if not api_key:
+        raise ProfileError(
+            f"{name}: environment variable {key_env} is not set "
+            "(api keys live only in the environment, never in the file)"
+        )
+    return LLMProfile(
+        name=name,
+        api_shape=shape,
+        base_url=base_url,
+        model=model,
+        api_key_env=key_env,
+        api_key=api_key,
+        max_tokens=int(raw.get("max_tokens") or DEFAULT_MAX_TOKENS),
+        timeout_sec=int(raw.get("timeout_sec") or DEFAULT_TIMEOUT_SEC),
+    )
+
+
+def load_profiles(path: Path, env: Mapping[str, str]) -> tuple[LLMProfile, LLMProfile, list[str]]:
+    """Loads the author+judge profiles. Raises ProfileError on hard errors;
+    a same-model pair is accepted with a warning (recommended, not mandatory:
+    context separation is guaranteed by the two independent HTTP calls)."""
+    if not path.exists():
+        raise ProfileError(
+            f"profiles file not found: {path} "
+            "(copy llm-profiles.yaml.example to llm-profiles.yaml and fill it in)"
+        )
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict) or "author" not in data or "judge" not in data:
+        raise ProfileError(f"{path.name}: expected top-level 'author' and 'judge' mappings")
+    author = _build_profile("author", data["author"], env)
+    judge = _build_profile("judge", data["judge"], env)
+    warnings: list[str] = []
+    if author.model == judge.model:
+        warnings.append(
+            "author and judge use the same model: a different judge model is "
+            "recommended for the adversarial gate (context separation still "
+            "holds via independent calls)"
+        )
+    return author, judge, warnings

--- a/core/src/tools/llm_client.py
+++ b/core/src/tools/llm_client.py
@@ -226,7 +226,16 @@ def complete(
         status: int | None
         try:
             status, payload = transport(url, headers, body, profile.timeout_sec)
-        except (urllib.error.URLError, OSError, TimeoutError) as exc:
+        # JSONDecodeError/UnicodeDecodeError: a 200 with a non-JSON or garbled body
+        # (e.g. a proxy error page) must stay inside the bounded-retry, secret-safe
+        # boundary.
+        except (
+            urllib.error.URLError,
+            OSError,
+            TimeoutError,
+            json.JSONDecodeError,
+            UnicodeDecodeError,
+        ) as exc:
             status, payload = None, {}
             last = f"network error: {exc.__class__.__name__}"
         if status == 200:

--- a/core/src/tools/llm_client.py
+++ b/core/src/tools/llm_client.py
@@ -110,3 +110,80 @@ def load_profiles(path: Path, env: Mapping[str, str]) -> tuple[LLMProfile, LLMPr
             "holds via independent calls)"
         )
     return author, judge, warnings
+
+
+def build_request(profile: LLMProfile, system: str, user: str) -> tuple[str, dict, dict]:
+    """One (system, user) exchange -> (url, headers, json body) for the shape."""
+    base = profile.base_url.rstrip("/")
+    if profile.api_shape == "anthropic":
+        return (
+            base + "/v1/messages",
+            {
+                "content-type": "application/json",
+                "x-api-key": profile.api_key,
+                "anthropic-version": "2023-06-01",
+            },
+            {
+                "model": profile.model,
+                "max_tokens": profile.max_tokens,
+                "system": system,
+                "messages": [{"role": "user", "content": user}],
+            },
+        )
+    return (
+        base + "/chat/completions",
+        {
+            "content-type": "application/json",
+            "authorization": f"Bearer {profile.api_key}",
+        },
+        {
+            "model": profile.model,
+            "max_tokens": profile.max_tokens,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+        },
+    )
+
+
+def parse_response(profile: LLMProfile, payload: dict) -> LLMResult:
+    """Extracts (text, stop_reason, truncated) from the shape's response body."""
+    if profile.api_shape == "anthropic":
+        blocks = payload.get("content") or []
+        text = "".join(b.get("text", "") for b in blocks if b.get("type") == "text")
+        stop = str(payload.get("stop_reason") or "")
+        return LLMResult(text=text, stop_reason=stop, truncated=stop == "max_tokens")
+    choices = payload.get("choices") or [{}]
+    message = choices[0].get("message") or {}
+    finish = str(choices[0].get("finish_reason") or "")
+    return LLMResult(
+        text=str(message.get("content") or ""),
+        stop_reason=finish,
+        truncated=finish == "length",
+    )
+
+
+def strip_code_fences(text: str) -> str:
+    """Removes a single outer ``` fence pair (models often add one despite the
+    addendum). Unbalanced fences are left untouched: the schema validation
+    downstream will reject them visibly instead of a silent edit here."""
+    s = text.strip()
+    if not s.startswith("```"):
+        return s
+    lines = s.splitlines()
+    if len(lines) >= 2 and lines[-1].strip() == "```":
+        return "\n".join(lines[1:-1]).strip()
+    return s
+
+
+def strip_frontmatter(text: str) -> str:
+    """Drops the YAML frontmatter block (harness metadata: name/model/...) from
+    a canonical contract, keeping the body used as the system prompt."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return text
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return "\n".join(lines[i + 1 :]).lstrip("\n")
+    return text

--- a/core/src/tools/llm_client.py
+++ b/core/src/tools/llm_client.py
@@ -124,7 +124,7 @@ def build_request(profile: LLMProfile, system: str, user: str) -> tuple[str, dic
             base + "/v1/messages",
             {
                 "content-type": "application/json",
-                "x-api-key": profile.api_key,
+                "x-api-key": profile.api_key,  # pragma: allowlist secret
                 "anthropic-version": "2023-06-01",
             },
             {

--- a/core/src/tools/pipeline.py
+++ b/core/src/tools/pipeline.py
@@ -938,6 +938,12 @@ def _register_phase2(sub) -> None:
         token_metrics.register(sub)
     except ImportError:
         pass
+    try:
+        import headless_l1
+
+        headless_l1.register(sub)
+    except ImportError:
+        pass
 
 
 _HANDLERS = {
@@ -995,6 +1001,10 @@ def main(argv: list[str] | None = None) -> int:
 
             if args.cmd in token_metrics.TOKEN_COMMANDS:
                 return token_metrics.dispatch(args)
+            import headless_l1
+
+            if args.cmd in headless_l1.COMMANDS:
+                return headless_l1.dispatch(args)
             import cli_loop
 
             return cli_loop.dispatch(args)

--- a/llm-profiles.yaml.example
+++ b/llm-profiles.yaml.example
@@ -9,6 +9,12 @@
 #   openai    = OpenAI chat completions  -> POST <base_url>/chat/completions
 #                (include the /v1 suffix in base_url when the provider uses it)
 #
+# The openai shape sends `max_tokens` (the field OpenAI-compatible providers
+# accept). OpenAI reasoning models (gpt-5, o-series) instead require
+# `max_completion_tokens` and will reject this form: pick a model that
+# accepts `max_tokens` (e.g. gpt-4.1) or route through an OpenAI-compatible
+# proxy that translates (e.g. LiteLLM).
+#
 # The judge SHOULD run on a different model than the author (adversarial-gate
 # recommendation); a same-model pair is accepted with a warning.
 author:
@@ -20,6 +26,6 @@ author:
 judge:
   api_shape: openai
   base_url: https://api.openai.com/v1
-  model: gpt-5
+  model: gpt-4.1
   api_key_env: OPENAI_API_KEY
   max_tokens: 16000

--- a/llm-profiles.yaml.example
+++ b/llm-profiles.yaml.example
@@ -1,0 +1,25 @@
+# LLM profiles for the headless L1 runner (`pipeline.py l1-run`).
+# Copy to llm-profiles.yaml (gitignored) and fill in.
+#
+# API keys are NEVER written in this file: `api_key_env` names the environment
+# variable that holds the key at runtime.
+#
+# api_shape:
+#   anthropic = Anthropic Messages API   -> POST <base_url>/v1/messages
+#   openai    = OpenAI chat completions  -> POST <base_url>/chat/completions
+#                (include the /v1 suffix in base_url when the provider uses it)
+#
+# The judge SHOULD run on a different model than the author (adversarial-gate
+# recommendation); a same-model pair is accepted with a warning.
+author:
+  api_shape: anthropic
+  base_url: https://api.anthropic.com
+  model: claude-sonnet-5
+  api_key_env: ANTHROPIC_API_KEY
+  max_tokens: 16000
+judge:
+  api_shape: openai
+  base_url: https://api.openai.com/v1
+  model: gpt-5
+  api_key_env: OPENAI_API_KEY
+  max_tokens: 16000


### PR DESCRIPTION
## Summary

Adds `pipeline.py l1-run`: a headless L1 runner that drives the existing author, adversarial judge and apply pipeline via direct single-shot LLM API calls, with no chat runner and no VS Code, so L1 ingest can run unattended from cron or CI.

It is a fourth door into the same pipeline, strictly additive. Claude Code, Codex CLI and the Copilot projection keep working unchanged; the canonical agent contracts are read as-is (a runtime addendum is composed per call, never saved); validation, adversarial gate, state machine and per-batch commits are the existing ones.

Context: the inference scenario discussed in [vscode_abap_remote_fs #473](https://github.com/marcellourbani/vscode_abap_remote_fs/issues/473). This is the programmatic path a `create_wiki`-style command or a Copilot (`vscode.lm`) proxy can drive: point `base_url` at any Anthropic-Messages-shaped or OpenAI-chat-completions-shaped endpoint.

## What's inside

- `core/src/tools/llm_client.py`: pure config and HTTP layer. Two profiles (author and judge) from a gitignored `llm-profiles.yaml` (tracked `.example`), with api keys read from environment variables only. Both wire shapes (Anthropic Messages, OpenAI chat completions) over stdlib `urllib`, so no new dependencies. Bounded retry with backoff; truncated, empty or malformed output fails closed; error messages never carry keys, prompts or responses.
- `core/src/tools/headless_l1.py`: the batch loop. recover, claim, author call (contract plus template plus line-numbered sources plus previous gate feedback), submit-author, judge call (pre-rendered deepcheck prompt), submit-verdict, apply, project, export, git commit. One run per invocation until the queue drains or `--max-batches` is reached. Exit codes: 0 drained, 1 open work or failures remain, 2 preflight error.
- Docs: new `core/docs/15-headless-l1-runner.md` plus updates to the runbook, runtime and cost doc, ABAP FS integration guide, README and CHANGELOG (`[1.2.0]`).

## Testing

- 521 unit tests plus 3 end-to-end tests that drive the `l1-run` command over a local HTTP stub impersonating both wire shapes: happy path to L1 with a git commit, REVERT then retry with the gate feedback verified inside the second author request, and broken output producing exit 1 with nothing promoted. An env-gated live smoke test (`ABAPWIKI_LIVE_SMOKE=1`) is skipped by default and never runs in CI.
- Full CI battery green locally: encoding, context headers, fail-closed secret scan, contract sync, ruff lint and format, wiki lint, and the no-SAP demo.

## Known follow-ups (documented in the runner guide)

- Very large single objects can hit connection drops on long non-streaming generations (handled by bounded retry and a clean task failure); streaming is a candidate improvement.
- Harden the profile `int()` casts to raise `ProfileError`; drain orphaned `l1_apply` tasks on empty batches; add a freshness check for retry feedback after `reopen-l1`.
- Date the `[1.2.0]` changelog entry at tag time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
