### PR TITLE
feat(sync_agents): --target exports the Copilot agents to an external workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to `abap_wiki` are documented in this file. The format is
 inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 follow [SemVer](https://semver.org/lang/en/).
 
+## [Unreleased]
+
+### Added
+
+- `sync_agents.py --target <workspace>`: exports the Copilot agent projection
+  to a VS Code workspace outside the wiki repo, for the ABAP FS case where the
+  folder open in the editor is not the wiki instance. Additive to the in-repo
+  copies, agents only (the skills stay in the repo, their commands are relative
+  to the wiki root), and outside the scope of `--check`, which stays
+  repo-scoped.
+
+### Changed
+
+- The Copilot projection now carries over a `model:` line already pinned in a
+  generated file instead of resetting it on every run. The body still comes
+  from the canonical contract, so engine upgrades land unchanged; only the one
+  field CLAUDE.md §15 declares user-owned is preserved. This matters in a
+  shared workspace, where that line is written by ABAP FS's own subagent
+  tooling.
+
 ## [1.2.0] - 2026-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -429,7 +429,12 @@ The canonical contracts live in `core/src/agentic/programs/` and are synchronise
 ```powershell
 .venv\Scripts\python core/src/tools/sync_agents.py
 .venv\Scripts\python core/src/tools/sync_agents.py --check
+.venv\Scripts\python core/src/tools/sync_agents.py --target <workspace>
 ```
+
+`--target` exports the Copilot agents to a VS Code workspace outside this repo,
+for the case where the folder open in the editor is not the wiki instance (see
+`core/docs/14-abap-fs-integration.md`).
 
 Do not manually edit the copies in `.agents/agents/` or `.claude/agents/`.
 

--- a/core/docs/05-runbook.md
+++ b/core/docs/05-runbook.md
@@ -107,6 +107,16 @@ python core/src/tools/sync_agents.py --check      # agent contracts in sync
 python core/src/tools/doctor.py                   # local prerequisites + config risks
 ```
 
+To make the Copilot agents available in a VS Code workspace that is not the
+wiki instance (the ABAP FS case), export them there:
+
+```
+python core/src/tools/sync_agents.py --target <workspace>
+```
+
+Agents only, additive to the in-repo copies, and outside the scope of
+`--check`. See [14-abap-fs-integration](14-abap-fs-integration.md).
+
 For what each check covers and how to read the results: [06-testing-and-quality](06-testing-and-quality.md).
 
 On a freshly cloned repo, `progress --json` returns a controlled JSON error

--- a/core/docs/14-abap-fs-integration.md
+++ b/core/docs/14-abap-fs-integration.md
@@ -80,7 +80,27 @@ either way no LLM shapes the result.
     canonical contracts by `sync_agents.py`; set each agent's `model:`
     line to a VS Code model (author premium, judge one tier below: same
     tiering ABAP FS documents for its subagents). The drift check ignores
-    the `model:` line.
+    the `model:` line, and a later `sync_agents.py` run carries your pinned
+    model over instead of resetting it.
+  - when the folder open in VS Code is **not** the wiki instance (the
+    normal ABAP FS case: you have the SAP project open, the wiki lives
+    elsewhere), export the projection into that workspace:
+
+    ```
+    .venv\Scripts\python core/src/tools/sync_agents.py --target <workspace>
+    ```
+
+    This writes `<workspace>/.github/agents/*.agent.md` in addition to the
+    in-repo copies. Only agents are exported: the skills stay in the wiki
+    repo, because their commands are relative to the wiki root and would
+    not resolve from another folder. `--check` remains repo-scoped, since a
+    workspace outside the repo is not something CI can police.
+
+    Note on co-location: ABAP FS enables and disables its own subagents by
+    renaming the whole `.github/agents` folder to `.github/agents_disabled`
+    (and deleting a previous `agents_disabled` recursively). Exported wiki
+    agents in that folder therefore follow those transitions. Re-running the
+    export restores them; agent ids do not collide.
   - skills: Copilot agent mode reads `.agents/skills/**/SKILL.md` natively.
   - instructions: enable `chat.useAgentsMdFile` so `AGENTS.md` loads
     automatically; `chat.customAgentInSubagent.enabled` allows agent

--- a/core/src/test/unit_tests/test_sync_agents.py
+++ b/core/src/test/unit_tests/test_sync_agents.py
@@ -155,6 +155,109 @@ def test_copilot_strip_is_scoped_to_frontmatter(repo):
     assert sync_agents.check(repo) == []
 
 
+# --- export to an external workspace (--target) ------------------------------
+
+
+def test_generate_exports_copilot_agents_to_target(repo, tmp_path):
+    _setup(repo)
+    target = tmp_path / "abapfs-workspace"
+    sync_agents.generate(repo, target=target)
+    for name in EXPECTED_AGENTS:
+        assert (target / COPILOT_DIR / f"{name}.agent.md").exists()
+
+
+def test_target_export_is_additive_to_the_in_repo_copies(repo, tmp_path):
+    _setup(repo)
+    sync_agents.generate(repo, target=tmp_path / "abapfs-workspace")
+    for name in EXPECTED_AGENTS:
+        assert (repo / COPILOT_DIR / f"{name}.agent.md").exists()
+        for invocable_dir in INVOCABLE_DIRS:
+            assert (repo / invocable_dir / f"{name}.md").exists()
+
+
+def test_target_export_strips_the_canonical_model_line(repo, tmp_path):
+    _setup(repo)
+    target = tmp_path / "abapfs-workspace"
+    sync_agents.generate(repo, target=target)
+    # the canonical deepcheck fixture carries "model: sonnet", a Claude alias
+    text = (target / COPILOT_DIR / "abap-deepcheck.agent.md").read_text(encoding="utf-8")
+    assert "model:" not in text
+    assert "# deepcheck" in text  # body preserved verbatim
+
+
+def test_check_ignores_the_target(repo, tmp_path):
+    _setup(repo)
+    target = tmp_path / "abapfs-workspace"
+    sync_agents.generate(repo, target=target)
+    (target / COPILOT_DIR / "abap-analyzer.agent.md").write_text(
+        "---\nname: abap-analyzer\n---\n# EDITED IN THE WORKSPACE\n", encoding="utf-8"
+    )
+    # the export lives outside the repo: the drift check stays repo-scoped
+    assert sync_agents.check(repo) == []
+
+
+def test_main_exports_to_target(repo, tmp_path, capsys):
+    _setup(repo)
+    target = tmp_path / "abapfs-workspace"
+    rc = sync_agents.main(["--target", str(target)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert (target / COPILOT_DIR / "abap-analyzer.agent.md").exists()
+    assert str(target) in out
+
+
+def _pin_model(path, model: str = "Claude Haiku 4.5") -> None:
+    content = path.read_text(encoding="utf-8")
+    name = content.split("name: ", 1)[1].split("\n", 1)[0]
+    path.write_text(
+        content.replace(f"name: {name}", f"name: {name}\nmodel: '{model}'", 1), encoding="utf-8"
+    )
+
+
+def test_target_export_preserves_a_user_pinned_model(repo, tmp_path):
+    _setup(repo)
+    target = tmp_path / "abapfs-workspace"
+    sync_agents.generate(repo, target=target)
+    path = target / COPILOT_DIR / "abap-analyzer.agent.md"
+    _pin_model(path)
+    # re-export, e.g. after upgrading the wiki sources: the model is the user's
+    # (and in the ABAP FS workspace it is written by Copilot's own tooling)
+    sync_agents.generate(repo, target=target)
+    assert "model: 'Claude Haiku 4.5'" in path.read_text(encoding="utf-8")
+
+
+def test_regenerate_preserves_a_user_pinned_model_in_repo(repo):
+    _setup(repo)
+    sync_agents.generate(repo)
+    path = repo / COPILOT_DIR / "abap-analyzer.agent.md"
+    _pin_model(path)
+    sync_agents.generate(repo)
+    assert "model: 'Claude Haiku 4.5'" in path.read_text(encoding="utf-8")
+
+
+def test_pinned_model_does_not_freeze_the_body(repo, tmp_path):
+    _setup(repo)
+    target = tmp_path / "abapfs-workspace"
+    sync_agents.generate(repo, target=target)
+    path = target / COPILOT_DIR / "abap-analyzer.agent.md"
+    _pin_model(path)
+    (repo / "core/src/agentic/programs/00-abap-analyzer.md").write_text(
+        "---\nname: abap-analyzer\n---\n# analyzer\nNEW CONTRACT BODY\n", encoding="utf-8"
+    )
+    sync_agents.generate(repo, target=target)
+    text = path.read_text(encoding="utf-8")
+    assert "NEW CONTRACT BODY" in text
+    assert "model: 'Claude Haiku 4.5'" in text
+
+
+def test_pinned_model_survives_and_check_still_sees_no_drift(repo):
+    _setup(repo)
+    sync_agents.generate(repo)
+    _pin_model(repo / COPILOT_DIR / "abap-deepcheck.agent.md")
+    sync_agents.generate(repo)
+    assert sync_agents.check(repo) == []
+
+
 # --- CLAUDE.md / AGENTS.md contract parity ----------------------------------
 
 

--- a/core/src/tools/sync_agents.py
+++ b/core/src/tools/sync_agents.py
@@ -12,7 +12,13 @@ makes drift impossible at zero runtime cost. A third target,
 custom agents with one deterministic transform: any frontmatter `model:` line is
 dropped, since the canonical value is a Claude-runner alias (e.g. `sonnet`) while
 the Copilot model is a per-user VS Code choice; `check()` strips the `model:` line
-from both sides before comparing, so a user-pinned model is not drift.
+from both sides before comparing, so a user-pinned model is not drift, and a
+regeneration carries the pinned line over instead of dropping it (the body still
+comes from the canonical contract, so engine upgrades land). `--target <workspace>`
+additionally exports that projection to a workspace outside the repo, for the ABAP
+FS scenario where the folder open in VS Code is not the wiki instance; the export
+is additive and `check()` stays repo-scoped, since CI cannot police a path outside
+the repo.
 contract_parity extracts the numbered `## N.` section bodies of CLAUDE.md and
 AGENTS.md, normalises whitespace, and reports a section-level drift summary (the
 preamble legitimately differs per runtime; CLAUDE.md is the source of truth).
@@ -73,6 +79,39 @@ def _strip_model_line(data: bytes) -> bytes:
     return data[:start] + _MODEL_LINE.sub(b"", data[start:end]) + data[end:]
 
 
+def _write_copilot_agent(path: Path, data: bytes) -> None:
+    """Writes the Copilot projection, carrying over a `model:` line the user
+    already pinned in that file. The body always comes from the canonical
+    contract, so an engine upgrade still lands; only the one field CLAUDE.md §15
+    declares user-owned is preserved. In an ABAP FS workspace that field is
+    written by the extension's own subagent tooling, so overwriting it on every
+    sync would silently drop the user's model choice."""
+    projected = _strip_model_line(data)
+    if not path.exists():
+        path.write_bytes(projected)
+        return
+    pinned = _frontmatter_model_line(path.read_bytes())
+    if pinned is None:
+        path.write_bytes(projected)
+        return
+    fm = _FRONTMATTER.match(projected)
+    if fm is None:  # no frontmatter to pin it into
+        path.write_bytes(projected)
+        return
+    end = fm.span(1)[1]
+    path.write_bytes(projected[:end] + pinned + projected[end:])
+
+
+def _frontmatter_model_line(data: bytes) -> bytes | None:
+    """The frontmatter `model:` line of an existing projection, newline included."""
+    fm = _FRONTMATTER.match(data)
+    if fm is None:
+        return None
+    start, end = fm.span(1)
+    found = _MODEL_LINE.search(data[start:end])
+    return found.group(0) if found else None
+
+
 def _display_path(root: Path, path: Path) -> str:
     return path.relative_to(root).as_posix()
 
@@ -81,13 +120,22 @@ def _sha(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def generate(root: Path) -> list[str]:
-    """Copies each canonical contract to the invocable copies. Returns the generated names."""
+def generate(root: Path, target: Path | None = None) -> list[str]:
+    """Copies each canonical contract to the invocable copies. Returns the generated names.
+
+    `target` additionally exports the Copilot projection to an external workspace
+    (`<target>/.github/agents/`), for the ABAP FS scenario where the wiki instance
+    is not the folder open in VS Code. The export is additive: the in-repo copies
+    are written exactly as without it, and `check` stays repo-scoped, since a
+    workspace outside the repo is not something CI can police."""
     agent_dirs = _agent_dirs(root)
     for agents in agent_dirs:
         agents.mkdir(parents=True, exist_ok=True)
-    copilot = _copilot_dir(root)
-    copilot.mkdir(parents=True, exist_ok=True)
+    copilot_dirs = [_copilot_dir(root)]
+    if target is not None:
+        copilot_dirs.append(_copilot_dir(target))
+    for copilot in copilot_dirs:
+        copilot.mkdir(parents=True, exist_ok=True)
     done = []
     for name, canonical in PROGRAMS.items():
         src = _programs_dir(root) / canonical
@@ -96,7 +144,8 @@ def generate(root: Path) -> list[str]:
         data = src.read_bytes()
         for agents in agent_dirs:
             (agents / f"{name}.md").write_bytes(data)
-        (copilot / f"{name}.agent.md").write_bytes(_strip_model_line(data))
+        for copilot in copilot_dirs:
+            _write_copilot_agent(copilot / f"{name}.agent.md", data)
         done.append(name)
     return done
 
@@ -209,6 +258,17 @@ def contract_parity(root: Path) -> list[str]:
     return drifts
 
 
+def _parse_target(argv: list[str]) -> Path | None:
+    """Reads `--target <dir>` from argv. Absent -> None; present without a value
+    -> ValueError, so a typo cannot silently degrade into a repo-only run."""
+    if "--target" not in argv:
+        return None
+    i = argv.index("--target")
+    if i + 1 >= len(argv) or argv[i + 1].startswith("-"):
+        raise ValueError("--target requires a workspace path")
+    return Path(argv[i + 1]).expanduser()
+
+
 def main(argv: list[str] | None = None) -> int:
     import db
 
@@ -222,8 +282,15 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         print("sync_agents: contracts in sync")
         return 0
-    done = generate(root)
+    try:
+        target = _parse_target(argv)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    done = generate(root, target=target)
     print(f"sync_agents: generated {len(done)} agents ({', '.join(done)})")
+    if target is not None:
+        print(f"sync_agents: exported {len(done)} Copilot agents to {_copilot_dir(target)}")
     return 0
 
 


### PR DESCRIPTION
Requested in [marcellourbani/vscode_abap_remote_fs#473](https://github.com/marcellourbani/vscode_abap_remote_fs/issues/473): "run `sync_agents.py`, but we need to add a target parameter here (in wiki side) so we can copy the agents and skills to the current ABAP FS workspace".

## What this adds

`sync_agents.py --target <workspace>` writes `<workspace>/.github/agents/*.agent.md` in addition to the in-repo copies. ABAP FS opens the SAP project, not the wiki instance, so the Copilot agent projection has to be able to land somewhere other than this repo.

**Agents only.** The skills stay here: their commands are relative to the wiki root (`core/src/tools/pipeline.py`, `.venv\`) and would not resolve from another folder. Exporting them verbatim would hand the user broken instructions.

**`--check` stays repo-scoped.** A workspace outside the repo is not something CI can police, so the export is an action, not a tracked target.

## Behaviour change worth reviewing

The Copilot projection no longer resets a `model:` line already pinned in a generated file. Previously every `sync_agents` run wiped it, which contradicted CLAUDE.md §15, where that line is the one documented exception the user owns. The body still comes from the canonical contract, so engine upgrades land unchanged.

This matters most in a shared workspace: ABAP FS's own `writeAgentFile` updates exactly that line when the user picks a model per tier from chat, so wiping it on every sync would fight their tooling.

## Verification

- `pytest core/src/test/unit_tests`: 530 passed, 1 skipped (the env-gated live smoke)
- `check_encoding --check`, `check_headers --check`, `doctor`, `doctor --secret-scan`, `sync_agents --check`, `slices-registry --check`, `lint_wiki --check`: all clean
- `ruff check` + `ruff format --check`: clean
- manual smoke against a scratch workspace: export lands, a pinned model survives re-export, `--target` without a value exits 2 with a clear message, output byte-identical across three consecutive runs

9 new tests, each watched failing before the implementation existed.

## Note for the ABAP FS side

Agent ids do not collide (the five projected here are absent from `AGENT_REGISTRY`), but ABAP FS enables and disables subagents by renaming the whole `.github/agents` folder, so co-located wiki agents follow those transitions. Documented in `core/docs/14-abap-fs-integration.md`; raised on the issue as something better fixed on their side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)